### PR TITLE
Fix JSEX use to its new name and bump its version.

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -21,7 +21,7 @@ defmodule Tentacat do
     status_code = response.status_code
     headers = response.headers
     body = response.body
-    response = unless body == "", do: body |> JSEX.decode!,
+    response = unless body == "", do: body |> JSX.decode!,
     else: nil
 
     if (status_code == 200), do: response,
@@ -50,7 +50,7 @@ defmodule Tentacat do
   end
 
   def json_request(method, url, body \\ "", headers \\ [], options \\ []) do
-    request!(method, url, JSEX.encode!(body), headers, options) |> process_response
+    request!(method, url, JSX.encode!(body), headers, options) |> process_response
   end
 
   def raw_request(method, url, body \\ "", headers \\ [], options \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -16,12 +16,12 @@ defmodule Tentacat.Mixfile do
   end
 
   def application do
-    [ applications: [ :httpoison, :jsex ] ]
+    [ applications: [ :httpoison, :exjsx ] ]
   end
 
   defp deps do
    [ { :httpoison, "~> 0.5.0" },
-     { :jsex, "~> 2.0" },
+     { :exjsx, "~> 3.0" },
      { :meck, "~> 0.8.2", only: :test } ]
   end
 

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -5,10 +5,10 @@ defmodule Tentacat.ClientTest do
   doctest Tentacat
 
   setup_all do
-    :meck.new(JSEX, [:no_link])
+    :meck.new(JSX, [:no_link])
 
     on_exit fn ->
-      :meck.unload JSEX
+      :meck.unload JSX
     end
   end
 
@@ -21,19 +21,19 @@ defmodule Tentacat.ClientTest do
   end
 
   test "process response on a 200 response" do
-    :meck.expect(JSEX, :decode!, 1, :decoded_json)
+    :meck.expect(JSX, :decode!, 1, :decoded_json)
     assert process_response(%HTTPoison.Response{ status_code: 200,
                                                  headers: %{},
                                                  body: "json" }) == :decoded_json
-    assert :meck.validate(JSEX)
+    assert :meck.validate(JSX)
   end
 
   test "process response on a non-200 response" do
-    :meck.expect(JSEX, :decode!, 1, :decoded_json)
+    :meck.expect(JSX, :decode!, 1, :decoded_json)
     assert process_response(%HTTPoison.Response{ status_code: 404,
                                                  headers: %{},
                                                  body: "json" }) == {404, :decoded_json}
-    assert :meck.validate(JSEX)
+    assert :meck.validate(JSX)
   end
 
   test "process response on a non-200 response and empty body" do


### PR DESCRIPTION
For some reason, decoding JSON was not working properly in the `Tentacat.Users` module. I found out that [JSEX was renamed](https://github.com/talentdeficit/jsex). This commit fixes this and bumps its version.
