### PR TITLE
support custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Getting info from a user using a client
 
 ```iex
 iex> client = %Tentacat.Client{}
-Tentacat.Client{auth: nil}
+%Tentacat.Client{auth: nil, endpoint: "https://api.github.com/"}
 iex> Tentacat.Users.find "edgurgel", client
 [{"login","edgurgel"},{"id",30873},{"avatar_url","https://secure.gravatar.com/avatar/5e0f65b214819fedf529220e19c08908?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"},{"gravatar_id","5e0f65b214819fedf529220e19c08908"},{"url","https://api.github.com/users/edgurgel"},{"html_url","https://github.com/edgurgel"},{"followers_url","https://api.github.com/users/edgurgel/followers"},{"following_url","https://api.github.com/users/edgurgel/following{/other_user}"},{"gists_url","https://api.github.com/users/edgurgel/gists{/gist_id}"},{"starred_url","https://api.github.com/users/edgurgel/starred{/owner}{/repo}"},{"subscriptions_url","https://api.github.com/users/edgurgel/subscriptions"},{"organizations_url","https://api.github.com/users/edgurgel/orgs"},{"repos_url","https://api.github.com/users/edgurgel/repos"},{"events_url","https://api.github.com/users/edgurgel/events{/privacy}"},{"received_events_url","https://api.github.com/users/edgurgel/received_events"},{"type","User"},{"name","Eduardo Gurgel"},{"company","Codeminer 42"},{"blog","http://gurgel.me"},{"location","Fortaleza, Brazil"},{"email","eduardo@gurgel.me"},{"hireable",false},{"bio",nil},{"public_repos",19},{"followers",16},{"following",38},{"created_at","2008-10-24T17:05:04Z"},{"updated_at","2013-06-18T22:52:41Z"},{"public_gists",4}]
 ```
@@ -73,16 +73,24 @@ Getting info from the authenticated user
 * Using user and password:
 
 ```iex
-iex> client = %Tentacat.Client{auth: %{user: "user", password: "password"}}
-Tentacat.Client{auth: %{user: "user", password: "password"}}
+iex> client = Tentacat.Client.new(%{user: "user", password: "password"})
+%Tentacat.Client{auth: %{user: "user", password: "password"}, endpoint: "https://api.github.com/"}
 iex> Tentacat.Users.me(client)
 ```
 
 * Using a personal access token [Github personal API token](https://github.com/blog/1509-personal-api-tokens)
 
 ```iex
-iex> client = %Tentacat.Client{auth: %{access_token: "928392873982932"}}
-Tentacat.Client{auth: %{access_token: "928392873982932"}}
+iex> client = Tentacat.Client.new(%{access_token: "928392873982932"})
+%Tentacat.Client{auth: %{access_token: "928392873982932"}, endpoint: "https://api.github.com/"}
+iex> Tentacat.Users.me(client)
+```
+
+Accessing another endpoint
+
+```iex
+iex> client = Tentacat.Client.new(%{access_token: "928392873982932"}, "https://ghe.example.com/api/v3/")
+%Tentacat.Client{auth: %{access_token: "928392873982932"}, endpoint: "https://ghe.example.com/api/v3/"}
 iex> Tentacat.Users.me(client)
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Every call to GitHub need a client, but if you want to use unauthenticated reque
 Getting info from a user using a client
 
 ```iex
-iex> client = %Tentacat.Client{}
+iex> client = Tentacat.Client.new
 %Tentacat.Client{auth: nil, endpoint: "https://api.github.com/"}
 iex> Tentacat.Users.find "edgurgel", client
 [{"login","edgurgel"},{"id",30873},{"avatar_url","https://secure.gravatar.com/avatar/5e0f65b214819fedf529220e19c08908?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png"},{"gravatar_id","5e0f65b214819fedf529220e19c08908"},{"url","https://api.github.com/users/edgurgel"},{"html_url","https://github.com/edgurgel"},{"followers_url","https://api.github.com/users/edgurgel/followers"},{"following_url","https://api.github.com/users/edgurgel/following{/other_user}"},{"gists_url","https://api.github.com/users/edgurgel/gists{/gist_id}"},{"starred_url","https://api.github.com/users/edgurgel/starred{/owner}{/repo}"},{"subscriptions_url","https://api.github.com/users/edgurgel/subscriptions"},{"organizations_url","https://api.github.com/users/edgurgel/orgs"},{"repos_url","https://api.github.com/users/edgurgel/repos"},{"events_url","https://api.github.com/users/edgurgel/events{/privacy}"},{"received_events_url","https://api.github.com/users/edgurgel/received_events"},{"type","User"},{"name","Eduardo Gurgel"},{"company","Codeminer 42"},{"blog","http://gurgel.me"},{"location","Fortaleza, Brazil"},{"email","eduardo@gurgel.me"},{"hireable",false},{"bio",nil},{"public_repos",19},{"followers",16},{"following",38},{"created_at","2008-10-24T17:05:04Z"},{"updated_at","2013-06-18T22:52:41Z"},{"public_gists",4}]

--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -6,6 +6,19 @@ defmodule Tentacat do
 
     @type auth :: %{user: binary, password: binary} | %{access_token: binary}
     @type t :: %__MODULE__{auth: auth, endpoint: binary}
+
+    @spec new(auth) :: t
+    def new(auth),  do: %__MODULE__{auth: auth}
+
+    @spec new(auth, binary) :: t
+    def new(auth, endpoint) do
+      endpoint = if String.ends_with?(endpoint, "/") do
+        endpoint
+      else
+        endpoint <> "/"
+      end
+      %__MODULE__{auth: auth, endpoint: endpoint}
+    end
   end
 
   @user_agent [{"User-agent", "tentacat"}]

--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -7,6 +7,9 @@ defmodule Tentacat do
     @type auth :: %{user: binary, password: binary} | %{access_token: binary}
     @type t :: %__MODULE__{auth: auth, endpoint: binary}
 
+    @spec new() :: t
+    def new(), do: %__MODULE__{}
+
     @spec new(auth) :: t
     def new(auth),  do: %__MODULE__{auth: auth}
 

--- a/lib/tentacat/contents.ex
+++ b/lib/tentacat/contents.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Contents do
   """
   @spec find(binary, binary, binary, Client.t) :: Tentacat.response
   def find(owner, repo, path, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/contents/#{path}", client.auth
+    get "repos/#{owner}/#{repo}/contents/#{path}", client
   end
 
   @doc """
@@ -29,7 +29,7 @@ defmodule Tentacat.Contents do
   """
   @spec find_in(binary, binary, binary, binary, Client.t) :: Tentacat.response
   def find_in(owner, repo, path, ref, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/contents/#{path}", client.auth, [{:ref, ref}]
+    get "repos/#{owner}/#{repo}/contents/#{path}", client, [{:ref, ref}]
   end
 
   @doc """
@@ -55,7 +55,7 @@ defmodule Tentacat.Contents do
   """
   @spec create(binary, binary, binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, path, body, client) do
-    put "repos/#{owner}/#{repo}/contents/#{path}", client.auth, body
+    put "repos/#{owner}/#{repo}/contents/#{path}", client, body
   end
 
   @doc """
@@ -82,7 +82,7 @@ defmodule Tentacat.Contents do
   """
   @spec update(binary, binary, binary, list | map, Client.t) :: Tentacat.response
   def update(owner, repo, path, body, client) do
-    put "repos/#{owner}/#{repo}/contents/#{path}", client.auth, body
+    put "repos/#{owner}/#{repo}/contents/#{path}", client, body
   end
 
   @doc """
@@ -108,6 +108,6 @@ defmodule Tentacat.Contents do
   """
   @spec remove(binary, binary, binary, list | map, Client.t) :: Tentacat.response
   def remove(owner, repo, path, body, client) do
-    delete "repos/#{owner}/#{repo}/contents/#{path}", client.auth, body
+    delete "repos/#{owner}/#{repo}/contents/#{path}", client, body
   end
 end

--- a/lib/tentacat/emails.ex
+++ b/lib/tentacat/emails.ex
@@ -13,7 +13,7 @@ defmodule Tentacat.Users.Emails do
   """
   @spec list(Client.t) :: Tentacat.response
   def list(client) do
-    get "user/emails", client.auth
+    get "user/emails", client
   end
 
   @doc """
@@ -27,7 +27,7 @@ defmodule Tentacat.Users.Emails do
   """
   @spec create([binary], Client.t) :: Tentacat.response
   def create(emails, client) do
-    post "user/emails", client.auth, emails
+    post "user/emails", client, emails
   end
 
   @doc """
@@ -41,6 +41,6 @@ defmodule Tentacat.Users.Emails do
   """
   @spec remove([binary], Client.t) :: Tentacat.response
   def remove(emails, client) do
-    delete "user/emails", client.auth, emails
+    delete "user/emails", client, emails
   end
 end

--- a/lib/tentacat/feeds.ex
+++ b/lib/tentacat/feeds.ex
@@ -20,7 +20,7 @@ defmodule Tentacat.Feeds do
   More info at: https://developer.github.com/v3/activity/feeds/
   """
   def feeds(client) do
-    get "feeds", client.auth
+    get "feeds", client
   end
 end
 

--- a/lib/tentacat/followers.ex
+++ b/lib/tentacat/followers.ex
@@ -13,7 +13,7 @@ defmodule Tentacat.Users.Followers do
   """
   @spec following(Client.t) :: Tentacat.response
   def following(client) do
-    get "user/following", client.auth
+    get "user/following", client
   end
 
   @doc """
@@ -26,7 +26,7 @@ defmodule Tentacat.Users.Followers do
   More info at: http://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
   """
   def following(user_name, client) do
-    get "users/#{user_name}/following", client.auth
+    get "users/#{user_name}/following", client
   end
 
   @doc """
@@ -40,7 +40,7 @@ defmodule Tentacat.Users.Followers do
   """
   @spec followers(Client.t) :: Tentacat.response
   def followers(client) do
-    get "user/followers", client.auth
+    get "user/followers", client
   end
 
   @doc """
@@ -53,7 +53,7 @@ defmodule Tentacat.Users.Followers do
   More info at: http://developer.github.com/v3/users/followers/#list-followers-of-a-user
   """
   def followers(user_name, client) do
-    get "users/#{user_name}/followers", client.auth
+    get "users/#{user_name}/followers", client
   end
 
   @doc """
@@ -83,7 +83,7 @@ defmodule Tentacat.Users.Followers do
   end
 
   defp following_check(following_api_url, client) do
-    case get following_api_url, client.auth do
+    case get following_api_url, client do
       { 204, _ } -> true
       { 404, _ } -> false
       unexpected_response -> unexpected_response
@@ -100,7 +100,7 @@ defmodule Tentacat.Users.Followers do
   More info at: https://developer.github.com/v3/users/followers/#follow-a-user
   """
   def follow(target_user, client) do
-    follow_response put "user/following/#{target_user}", client.auth
+    follow_response put "user/following/#{target_user}", client
   end
 
   @doc """
@@ -113,7 +113,7 @@ defmodule Tentacat.Users.Followers do
   More info at: https://developer.github.com/v3/users/followers/#unfollow-a-user
   """
   def unfollow(target_user, client) do
-    follow_response delete "user/following/#{target_user}", client.auth
+    follow_response delete "user/following/#{target_user}", client
   end
 
   defp follow_response(response) do

--- a/lib/tentacat/gitignore.ex
+++ b/lib/tentacat/gitignore.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Gitignore do
   """
   @spec templates(Client.t) :: Tentacat.response
   def templates(client \\ %Client{}) do
-    get "gitignore/templates", client.auth
+    get "gitignore/templates", client
   end
 
   @doc """
@@ -30,7 +30,7 @@ defmodule Tentacat.Gitignore do
   # FIXME We should support raw data type too
   @spec template(binary, Client.t) :: Tentacat.response
   def template(name, client \\ %Client{}) do
-    get "gitignore/templates/#{name}", client.auth
+    get "gitignore/templates/#{name}", client
   end
 end
 

--- a/lib/tentacat/hooks.ex
+++ b/lib/tentacat/hooks.ex
@@ -16,7 +16,7 @@ defmodule Tentacat.Hooks do
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, client) do
-    get "repos/#{owner}/#{repo}/hooks", client.auth
+    get "repos/#{owner}/#{repo}/hooks", client
   end
 
   @doc """
@@ -30,7 +30,7 @@ defmodule Tentacat.Hooks do
   """
   @spec find(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def find(owner, repo, hook_id, client) do
-    get "repos/#{owner}/#{repo}/hooks/#{hook_id}", client.auth
+    get "repos/#{owner}/#{repo}/hooks/#{hook_id}", client
   end
 
   @doc """
@@ -44,7 +44,7 @@ defmodule Tentacat.Hooks do
   """
   @spec create(binary, binary, list, Client.t) :: Tentacat.response
   def create(owner, repo, body, client) do
-    post "repos/#{owner}/#{repo}/hooks", client.auth, body
+    post "repos/#{owner}/#{repo}/hooks", client, body
   end
 
   @doc """
@@ -57,7 +57,7 @@ defmodule Tentacat.Hooks do
   """
   @spec update(binary, binary, binary | integer, list, Client.t) :: Tentacat.response
   def update(owner, repo, hook_id, body, client) do
-    patch "repos/#{owner}/#{repo}/hooks/#{hook_id}", client.auth, body
+    patch "repos/#{owner}/#{repo}/hooks/#{hook_id}", client, body
   end
 
   @doc """
@@ -72,7 +72,7 @@ defmodule Tentacat.Hooks do
   """
   @spec test(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def test(owner, repo, hook_id, client) do
-    post "repos/#{owner}/#{repo}/hooks/#{hook_id}/test", client.auth, ""
+    post "repos/#{owner}/#{repo}/hooks/#{hook_id}/test", client, ""
   end
 
   @doc """
@@ -86,7 +86,7 @@ defmodule Tentacat.Hooks do
   """
   @spec remove(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def remove(owner, repo, hook_id, client) do
-    delete "repos/#{owner}/#{repo}/hooks/#{hook_id}", client.auth
+    delete "repos/#{owner}/#{repo}/hooks/#{hook_id}", client
   end
 
 end

--- a/lib/tentacat/keys.ex
+++ b/lib/tentacat/keys.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec list(binary, Client.t) :: Tentacat.response
   def list(user, client \\ %Client{}) do
-    get "users/#{user}/keys", client.auth
+    get "users/#{user}/keys", client
   end
 
   @doc """
@@ -28,7 +28,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec list_mine(Client.t) :: Tentacat.response
   def list_mine(client) do
-    get "user/keys", client.auth
+    get "user/keys", client
   end
 
   @doc """
@@ -42,7 +42,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec find(integer, Client.t) :: Tentacat.response
   def find(id, client) do
-    get "user/keys/#{id}", client.auth
+    get "user/keys/#{id}", client
   end
 
   @doc """
@@ -56,7 +56,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec create(binary, binary, Client.t) :: Tentacat.response
   def create(title, key, client) do
-    post "user/keys", client.auth, [title: title, key: key]
+    post "user/keys", client, [title: title, key: key]
   end
 
   @doc """
@@ -70,7 +70,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec update(integer, binary, binary, Client.t) :: Tentacat.response
   def update(id, title, key, client) do
-    patch "user/keys/#{id}", client.auth, [title: title, key: key]
+    patch "user/keys/#{id}", client, [title: title, key: key]
   end
 
   @doc """
@@ -84,6 +84,6 @@ defmodule Tentacat.Users.Keys do
   """
   @spec remove(integer, Client.t) :: any
   def remove(id, client) do
-    delete "user/keys/#{id}", client.auth
+    delete "user/keys/#{id}", client
   end
 end

--- a/lib/tentacat/organizations.ex
+++ b/lib/tentacat/organizations.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Organizations do
   """
   @spec list(binary, Client.t) :: Tentacat.response
   def list(user, client \\ %Client{}) do
-    get "users/#{user}/orgs", client.auth
+    get "users/#{user}/orgs", client
   end
 
   @doc """
@@ -28,7 +28,7 @@ defmodule Tentacat.Organizations do
   """
   @spec list_mine(Client.t) :: Tentacat.response
   def list_mine(client) do
-    get "user/orgs", client.auth
+    get "user/orgs", client
   end
 
   @doc """
@@ -43,7 +43,7 @@ defmodule Tentacat.Organizations do
   """
   @spec find(binary, Client.t) :: Tentacat.response
   def find(org, client \\ %Client{}) do
-    get "orgs/#{org}", client.auth
+    get "orgs/#{org}", client
   end
 
   @doc """
@@ -65,6 +65,6 @@ defmodule Tentacat.Organizations do
   """
   @spec update(binary, list, Client.t) :: Tentacat.response
   def update(org, options, client) do
-    patch "orgs/#{org}", client.auth, options
+    patch "orgs/#{org}", client, options
   end
 end

--- a/lib/tentacat/organizations/members.ex
+++ b/lib/tentacat/organizations/members.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec list(binary, Client.t) :: Tentacat.response
   def list(organization, client \\ %Client{}) do
-    get "orgs/#{organization}/members", client.auth
+    get "orgs/#{organization}/members", client
   end
 
   @doc """
@@ -31,7 +31,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec member?(binary, binary, Client.t) :: Tentacat.response
   def member?(organization, user, client \\ %Client{}) do
-    get "orgs/#{organization}/members/#{user}", client.auth
+    get "orgs/#{organization}/members/#{user}", client
   end
 
   @doc """
@@ -45,7 +45,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec remove(binary, binary, Client.t) :: Tentacat.response
   def remove(organization, user, client) do
-    delete "orgs/#{organization}/members/#{user}", client.auth
+    delete "orgs/#{organization}/members/#{user}", client
   end
 
   @doc """
@@ -60,7 +60,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec public_list(binary, Client.t) :: Tentacat.response
   def public_list(organization, client \\ %Client{}) do
-    get "orgs/#{organization}/public_members", client.auth
+    get "orgs/#{organization}/public_members", client
   end
 
   @doc """
@@ -77,7 +77,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec public_member?(binary, binary, Client.t) :: Tentacat.response
   def public_member?(organization, user, client \\ %Client{}) do
-    get "orgs/#{organization}/public_members/#{user}", client.auth
+    get "orgs/#{organization}/public_members/#{user}", client
   end
 
   @doc """
@@ -91,7 +91,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec publicize(binary, binary, Client.t) :: Tentacat.response
   def publicize(organization, user, client) do
-    put "orgs/#{organization}/public_members/#{user}", client.auth
+    put "orgs/#{organization}/public_members/#{user}", client
   end
 
   @doc """
@@ -105,7 +105,7 @@ defmodule Tentacat.Organizations.Members do
   """
   @spec conceal(binary, binary, Client.t) :: Tentacat.response
   def conceal(organization, user, client) do
-    delete "orgs/#{organization}/public_members/#{user}", client.auth
+    delete "orgs/#{organization}/public_members/#{user}", client
   end
 
 end

--- a/lib/tentacat/pulls.ex
+++ b/lib/tentacat/pulls.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Pulls do
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls", client.auth
+    get "repos/#{owner}/#{repo}/pulls", client
   end
 
   @doc """
@@ -29,7 +29,7 @@ defmodule Tentacat.Pulls do
   """
   @spec find(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def find(owner, repo, number, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls/#{number}", client.auth
+    get "repos/#{owner}/#{repo}/pulls/#{number}", client
   end
 
   @doc """
@@ -60,7 +60,7 @@ defmodule Tentacat.Pulls do
   """
   @spec create(binary, binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, body, client) do
-    post "repos/#{owner}/#{repo}/pulls", client.auth, body
+    post "repos/#{owner}/#{repo}/pulls", client, body
   end
 
   @doc """
@@ -82,6 +82,6 @@ defmodule Tentacat.Pulls do
   """
   @spec update(binary, binary, binary | integer, list | map, Client.t) :: Tentacat.response
   def update(owner, repo, number, body, client) do
-    patch "repos/#{owner}/#{repo}/pulls/#{number}", client.auth, body
+    patch "repos/#{owner}/#{repo}/pulls/#{number}", client, body
   end
 end

--- a/lib/tentacat/pulls/comments.ex
+++ b/lib/tentacat/pulls/comments.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Pulls.Comments do
   """
   @spec list_all(binary, binary, Client.t) :: Tentacat.response
   def list_all(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls/comments", client.auth
+    get "repos/#{owner}/#{repo}/pulls/comments", client
   end
 
   @doc """
@@ -29,7 +29,7 @@ defmodule Tentacat.Pulls.Comments do
   """
   @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def list(owner, repo, number, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls/#{number}/comments", client.auth
+    get "repos/#{owner}/#{repo}/pulls/#{number}/comments", client
   end
 
   @doc """
@@ -44,7 +44,7 @@ defmodule Tentacat.Pulls.Comments do
   """
   @spec find(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def find(owner, repo, comment_id, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client.auth
+    get "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client
   end
 
   @doc """
@@ -68,7 +68,7 @@ defmodule Tentacat.Pulls.Comments do
   """
   @spec create(binary, binary, integer | binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, number, body, client) do
-    post "repos/#{owner}/#{repo}/pulls/#{number}/comments", client.auth, body
+    post "repos/#{owner}/#{repo}/pulls/#{number}/comments", client, body
   end
 
   @doc """
@@ -82,7 +82,7 @@ defmodule Tentacat.Pulls.Comments do
   """
   @spec update(binary, binary, binary | integer, list, Client.t) :: Tentacat.response
   def update(owner, repo, comment_id, body, client) do
-    patch "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client.auth, body
+    patch "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client, body
   end
 
   @doc """
@@ -96,6 +96,6 @@ defmodule Tentacat.Pulls.Comments do
   """
   @spec remove(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def remove(owner, repo, comment_id, client) do
-    delete "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client.auth
+    delete "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client
   end
 end

--- a/lib/tentacat/pulls/commits.ex
+++ b/lib/tentacat/pulls/commits.ex
@@ -14,6 +14,6 @@ defmodule Tentacat.Pulls.Commits do
   """
   @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def list(owner, repo, number, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls/#{number}/commits", client.auth
+    get "repos/#{owner}/#{repo}/pulls/#{number}/commits", client
   end
 end

--- a/lib/tentacat/pulls/files.ex
+++ b/lib/tentacat/pulls/files.ex
@@ -14,6 +14,6 @@ defmodule Tentacat.Pulls.Files do
   """
   @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def list(owner, repo, number, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/pulls/#{number}/files", client.auth
+    get "repos/#{owner}/#{repo}/pulls/#{number}/files", client
   end
 end

--- a/lib/tentacat/references.ex
+++ b/lib/tentacat/references.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.References do
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/git/refs", client.auth
+    get "repos/#{owner}/#{repo}/git/refs", client
   end
 
   @doc """
@@ -29,7 +29,7 @@ defmodule Tentacat.References do
   """
   @spec find(binary, binary, binary, Client.t) :: Tentacat.response
   def find(owner, repo, ref, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/git/refs/#{ref}", client.auth
+    get "repos/#{owner}/#{repo}/git/refs/#{ref}", client
   end
 
   @doc """
@@ -50,7 +50,7 @@ defmodule Tentacat.References do
   """
   @spec create(binary, binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, body, client) do
-    post "repos/#{owner}/#{repo}/git/refs", client.auth, body
+    post "repos/#{owner}/#{repo}/git/refs", client, body
   end
 
   @doc """
@@ -71,7 +71,7 @@ defmodule Tentacat.References do
   """
   @spec update(binary, binary, binary, list | map, Client.t) :: Tentacat.response
   def update(owner, repo, ref, body, client) do
-    patch "repos/#{owner}/#{repo}/git/refs/#{ref}", client.auth, body
+    patch "repos/#{owner}/#{repo}/git/refs/#{ref}", client, body
   end
 
   @doc """
@@ -86,6 +86,6 @@ defmodule Tentacat.References do
   """
   @spec remove(binary, binary, binary, Client.t) :: Tentacat.response
   def remove(owner, repo, ref, client) do
-    delete "repos/#{owner}/#{repo}/git/refs/#{ref}", client.auth
+    delete "repos/#{owner}/#{repo}/git/refs/#{ref}", client
   end
 end

--- a/lib/tentacat/releases.ex
+++ b/lib/tentacat/releases.ex
@@ -13,7 +13,7 @@ defmodule Tentacat.Releases do
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/releases", client.auth
+    get "repos/#{owner}/#{repo}/releases", client
   end
 
   @doc """
@@ -27,7 +27,7 @@ defmodule Tentacat.Releases do
   """
   @spec find(integer, binary, binary, Client.t) :: Tentacat.response
   def find(id, owner, repo, client \\ %Client{}) when is_integer(id) do
-    get "repos/#{owner}/#{repo}/releases/#{id}", client.auth
+    get "repos/#{owner}/#{repo}/releases/#{id}", client
   end
 
   @doc """
@@ -42,7 +42,7 @@ defmodule Tentacat.Releases do
   @spec create(binary, binary, binary, Client.t, list) :: Tentacat.response
   def create(tag_name, owner, repo, client \\ %Client{}, options \\ []) when is_binary(tag_name) do
     body = Dict.merge(options, tag_name: tag_name)
-    post "repos/#{owner}/#{repo}/releases", client.auth, body
+    post "repos/#{owner}/#{repo}/releases", client, body
   end
 
   @doc """
@@ -65,7 +65,7 @@ defmodule Tentacat.Releases do
   """
   @spec edit(integer, binary, binary, Client.t, list) :: Tentacat.response
   def edit(id, owner, repo, client \\ %Client{}, options \\ []) when is_integer(id) do
-    patch "repos/#{owner}/#{repo}/releases/#{id}", client.auth, options
+    patch "repos/#{owner}/#{repo}/releases/#{id}", client, options
   end
 
   @doc """
@@ -79,6 +79,6 @@ defmodule Tentacat.Releases do
   """
   @spec delete(integer, binary, binary, Client.t) :: Tentacat.response
   def delete(id, owner, repo, client \\ %Client{}) when is_integer(id) do
-    delete "repos/#{owner}/#{repo}/releases/#{id}", client.auth
+    delete "repos/#{owner}/#{repo}/releases/#{id}", client
   end
 end

--- a/lib/tentacat/releases/assets.ex
+++ b/lib/tentacat/releases/assets.ex
@@ -19,7 +19,7 @@ defmodule Tentacat.Releases.Assets do
   """
   @spec list(integer, binary, binary, Client.t) :: Tentacat.response
   def list(id, owner, repo, client \\ %Client{}) when is_integer(id) do
-    get "repos/#{owner}/#{repo}/releases/#{id}/assets", client.auth
+    get "repos/#{owner}/#{repo}/releases/#{id}/assets", client
   end
 
   @doc """
@@ -33,7 +33,7 @@ defmodule Tentacat.Releases.Assets do
   """
   @spec find(integer, binary, binary, Client.t) :: Tentacat.response
   def find(id, owner, repo, client \\ %Client{}) when is_integer(id) do
-    get "repos/#{owner}/#{repo}/releases/assets/#{id}", client.auth
+    get "repos/#{owner}/#{repo}/releases/assets/#{id}", client
   end
 
   @doc """
@@ -52,7 +52,7 @@ defmodule Tentacat.Releases.Assets do
   @spec edit(binary, integer, binary, binary, Client.t, list) :: Tentacat.response
   def edit(name, id, owner, repo, client \\ %Client{}, options \\ []) when is_integer(id) do
     body = Dict.merge(options, name: name)
-    patch "repos/#{owner}/#{repo}/releases/assets/#{id}", client.auth, body
+    patch "repos/#{owner}/#{repo}/releases/assets/#{id}", client, body
   end
 
   @doc """
@@ -66,7 +66,7 @@ defmodule Tentacat.Releases.Assets do
   """
   @spec delete(integer, binary, binary, Client.t) :: Tentacat.response
   def delete(id, owner, repo, client \\ %Client{}) when is_integer(id) do
-    delete "repos/#{owner}/#{repo}/releases/assets/#{id}", client.auth
+    delete "repos/#{owner}/#{repo}/releases/assets/#{id}", client
   end
 
   #

--- a/lib/tentacat/repositories.ex
+++ b/lib/tentacat/repositories.ex
@@ -17,7 +17,7 @@ defmodule Tentacat.Repositories do
   """
   @spec list_mine(Client.t) :: Tentacat.response
   def list_mine(client) do
-    get "user/repos", client.auth
+    get "user/repos", client
   end
 
   @doc """
@@ -31,7 +31,7 @@ defmodule Tentacat.Repositories do
   """
   @spec list_users(binary, Client.t) :: Tentacat.response
   def list_users(owner, client \\ %Client{}) do
-    get "users/#{owner}/repos", client.auth
+    get "users/#{owner}/repos", client
   end
 
   @doc """
@@ -45,7 +45,7 @@ defmodule Tentacat.Repositories do
   """
   @spec list_orgs(binary, Client.t) :: Tentacat.response
   def list_orgs(org, client \\ %Client{}) do
-    get "orgs/#{org}/repos", client.auth
+    get "orgs/#{org}/repos", client
   end
 
 

--- a/lib/tentacat/repositories/branches.ex
+++ b/lib/tentacat/repositories/branches.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Repositories.Branches do
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/branches", client.auth
+    get "repos/#{owner}/#{repo}/branches", client
   end
 
   @doc """
@@ -29,6 +29,6 @@ defmodule Tentacat.Repositories.Branches do
   """
   @spec find(binary, binary, binary, Client.t) :: Tentacat.response
   def find(owner, repo, branch, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/branches/#{branch}", client.auth
+    get "repos/#{owner}/#{repo}/branches/#{branch}", client
   end
 end

--- a/lib/tentacat/repositories/deployments.ex
+++ b/lib/tentacat/repositories/deployments.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Repositories.Deployments do
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/deployments", client.auth
+    get "repos/#{owner}/#{repo}/deployments", client
   end
 
   @doc """
@@ -37,7 +37,7 @@ defmodule Tentacat.Repositories.Deployments do
   """
   @spec create(binary, binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, body, client ) do
-    post "repos/#{owner}/#{repo}/deployments", client.auth, body
+    post "repos/#{owner}/#{repo}/deployments", client, body
   end
 
   @doc """
@@ -52,7 +52,7 @@ defmodule Tentacat.Repositories.Deployments do
   """
   @spec list_statuses(binary, binary, binary | integer, Client.t) :: Tentacat.response
   def list_statuses(owner, repo, id, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/deployments/#{id}/statuses", client.auth
+    get "repos/#{owner}/#{repo}/deployments/#{id}/statuses", client
   end
 
   @doc """
@@ -75,6 +75,6 @@ defmodule Tentacat.Repositories.Deployments do
   """
   @spec create_status(binary, binary, binary, list | map, Client.t) :: Tentacat.response
   def create_status(owner, repo, id, body, client) do
-    post "repos/#{owner}/#{repo}/deployments/#{id}/statuses", client.auth, body
+    post "repos/#{owner}/#{repo}/deployments/#{id}/statuses", client, body
   end
 end

--- a/lib/tentacat/repositories/statuses.ex
+++ b/lib/tentacat/repositories/statuses.ex
@@ -15,7 +15,7 @@ defmodule Tentacat.Repositories.Statuses do
   """
   @spec list(binary, binary, binary, Client.t) :: Tentacat.response
   def list(owner, repo, ref, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/commits/#{ref}/statuses", client.auth
+    get "repos/#{owner}/#{repo}/commits/#{ref}/statuses", client
   end
 
   @doc """
@@ -31,7 +31,7 @@ defmodule Tentacat.Repositories.Statuses do
   """
   @spec find(binary, binary, binary, Client.t) :: Tentacat.response
   def find(owner, repo, ref, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/commits/#{ref}/status", client.auth
+    get "repos/#{owner}/#{repo}/commits/#{ref}/status", client
   end
 
   @doc """
@@ -55,6 +55,6 @@ defmodule Tentacat.Repositories.Statuses do
   """
   @spec create(binary, binary, binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, sha, body, client) do
-    post "repos/#{owner}/#{repo}/statuses/#{sha}", client.auth, body
+    post "repos/#{owner}/#{repo}/statuses/#{sha}", client, body
   end
 end

--- a/lib/tentacat/starring.ex
+++ b/lib/tentacat/starring.ex
@@ -13,7 +13,7 @@ defmodule Tentacat.Users.Starring do
   """
   @spec starred(Client.t) :: Tentacat.response
   def starred(client) do
-    get "user/starred", client.auth
+    get "user/starred", client
   end
 
   @doc """
@@ -27,6 +27,6 @@ defmodule Tentacat.Users.Starring do
   """
   @spec starred(binary, Client.t) :: Tentacat.response
   def starred(user_name, client) do
-    get "users/#{user_name}/starred", client.auth
+    get "users/#{user_name}/starred", client
   end
 end

--- a/lib/tentacat/trees.ex
+++ b/lib/tentacat/trees.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Trees do
   """
   @spec find(binary, binary, binary, Client.t) :: Tentacat.response
   def find(owner, repo, sha, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/git/trees/#{sha}", client.auth
+    get "repos/#{owner}/#{repo}/git/trees/#{sha}", client
   end
 
   @doc """
@@ -29,7 +29,7 @@ defmodule Tentacat.Trees do
   """
   @spec find_recursive(binary, binary, binary, Client.t) :: Tentacat.response
   def find_recursive(owner, repo, sha, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/git/trees/#{sha}", client.auth, [{:recursive, 1}]
+    get "repos/#{owner}/#{repo}/git/trees/#{sha}", client, [{:recursive, 1}]
   end
 
   @doc """
@@ -57,6 +57,6 @@ defmodule Tentacat.Trees do
   """
   @spec create(binary, binary, list | map, Client.t) :: Tentacat.response
   def create(owner, repo, body, client) do
-    post "repos/#{owner}/#{repo}/git/trees", client.auth, body
+    post "repos/#{owner}/#{repo}/git/trees", client, body
   end
 end

--- a/lib/tentacat/users.ex
+++ b/lib/tentacat/users.ex
@@ -14,7 +14,7 @@ defmodule Tentacat.Users do
   """
   @spec find(binary, Client.t) :: Tentacat.response
   def find(user, client \\ %Client{}) do
-    get "users/#{user}", client.auth
+    get "users/#{user}", client
   end
 
   @doc """
@@ -28,7 +28,7 @@ defmodule Tentacat.Users do
   """
   @spec me(Client.t) :: Tentacat.response
   def me(client) do
-    get "user", client.auth
+    get "user", client
   end
 
   @doc """
@@ -43,7 +43,7 @@ defmodule Tentacat.Users do
   """
   @spec list(Client.t) :: Tentacat.response
   def list(client \\ %Client{}) do
-    get "users", client.auth
+    get "users", client
   end
 
   @doc """
@@ -58,7 +58,7 @@ defmodule Tentacat.Users do
   """
   @spec list_since(integer, Client.t) :: Tentacat.response
   def list_since(since, client \\ %Client{}) do
-    get "users", client.auth, [since: since]
+    get "users", client, [since: since]
   end
 
   @doc """
@@ -82,6 +82,6 @@ defmodule Tentacat.Users do
   """
   @spec update(Keyword.t, Client.t) :: Tentacat.response
   def update(options, client) do
-    patch "user", client.auth, options
+    patch "user", client, options
   end
 end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -20,6 +20,22 @@ defmodule Tentacat.ClientTest do
     assert authorization_header(%{access_token: "9820103"}, []) == [{"Authorization", "token 9820103"}]
   end
 
+  test "default endpoint" do
+    client = Tentacat.Client.new(%{})
+    assert client.endpoint == "https://api.github.com/"
+  end
+
+  test "custom endpoint" do
+    expected = "https://ghe.foo.com/api/v3/"
+
+    client = Tentacat.Client.new(%{}, "https://ghe.foo.com/api/v3/")
+    assert client.endpoint == expected
+
+    # when tailing '/' is missing
+    client = Tentacat.Client.new(%{}, "https://ghe.foo.com/api/v3")
+    assert client.endpoint == expected
+  end
+
   test "process response on a 200 response" do
     :meck.expect(JSX, :decode!, 1, :decoded_json)
     assert process_response(%HTTPoison.Response{ status_code: 200,


### PR DESCRIPTION
This pull request make tentacat to support custom endpoint.
The main purpose is to access github enterprise API.

- Changes
  - add new item `endpoint` to `Tentacat.Client` struct.
  - implement `Tentacat.Client.new/1` and `Tentacat.Client.new/2`.

I'd appreciate any feedback. Thank you.