### PR TITLE
Add filters to pulls and Issues retrieving capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You will something like this:
 Erlang/OTP 17 [erts-6.0] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]
 
 Interactive Elixir (0.13.3) - press Ctrl+C to exit (type h() ENTER for help)
-iex(1)>
+iex(1)> Tentacat.start
 ```
 
 Now you can run the examples!

--- a/lib/tentacat/issues.ex
+++ b/lib/tentacat/issues.ex
@@ -1,0 +1,49 @@
+defmodule Tentacat.Issues do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  List issues
+
+  ## Example
+
+      Tentacat.Issues.list "elixir-lang", "elixir"
+      Tentacat.Issues.list "elixir-lang", "elixir", client
+
+  More info at: https://developer.github.com/v3/issues/#list-issues
+  """
+  @spec list(binary, binary, Client.t) :: Tentacat.response
+  def list(owner, repo, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/issues", client
+  end
+
+@doc """
+  Filter issues
+
+  ## Example
+
+      Tentacat.Issues.list "elixir-lang", "elixir", %{state: "open"}
+      Tentacat.Issues.list "elixir-lang", "elixir", %{state: "open"}, client
+
+  More info at: https://developer.github.com/v3/pulls/#parameters
+  """
+  @spec filter(binary, binary, map, Client.t) :: Tentacat.response
+  def filter(owner, repo, filters, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/issues?#{URI.encode_query(filters)}", client
+  end
+
+  @doc """
+  Get a single issue
+
+  ## Example
+
+      Tentacat.Issues.find "elixir-lang", "elixir", "2974"
+      Tentacat.Issues.find "elixir-lang", "elixir", "2974", client
+
+  More info at: https://developer.github.com/v3/pulls/#get-a-single-issue
+  """
+  @spec find(binary, binary, binary | integer, Client.t) :: Tentacat.response
+  def find(owner, repo, number, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/issues/#{number}", client
+  end
+end

--- a/lib/tentacat/pulls.ex
+++ b/lib/tentacat/pulls.ex
@@ -17,6 +17,21 @@ defmodule Tentacat.Pulls do
     get "repos/#{owner}/#{repo}/pulls", client
   end
 
+@doc """
+  Filter pull requests
+
+  ## Example
+
+      Tentacat.Pulls.list "elixir-lang", "elixir", %{state: "open"}
+      Tentacat.Pulls.list "elixir-lang", "elixir", %{state: "open"}, client
+
+  More info at: https://developer.github.com/v3/pulls/#parameters
+  """
+  @spec filter(binary, binary, map, Client.t) :: Tentacat.response
+  def filter(owner, repo, filters, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/pulls?#{URI.encode_query(filters)}", client
+  end
+
   @doc """
   Get a single pull request
 


### PR DESCRIPTION
By receiving a `filters` map and passing it through `URI.encode_query/1` it is
already prepared for future filters implemented on Github.

Also adds a new module to list and find issues.