### PR TITLE
Updated version of httpoison

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Tentacat.Mixfile do
   end
 
   defp deps do
-   [ { :httpoison, "~> 0.6.0" },
+   [ { :httpoison, "~> 0.7.3" },
      { :exjsx, "~> 3.0" },
      { :meck, "~> 0.8.2", only: :test } ]
   end


### PR DESCRIPTION
Hi All!

Newbie to the elixir world so sorry if this isn't right...

I recently added tentacat to my Phoenix project, running mix eps.get complained:

Looking up alternatives for conflicting requirements on httpoison
  From mix.lock: 0.7.3
  From tentacat v0.1.5: ~> 0.6.0
** (Mix) Hex dependency resolution failed, relax the version requirements or unlock dependencies

Updating the version of httpoison in tentacat fixed this. 

MIX_ENV=test mix do deps.get, test

Runs fine. 
