### PR TITLE
fix url to doc on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Tentacool + Cat = Tentacat
   * Statuses
   * Deployments
 
-Documentation can be found [here](hexdocs.pm/tentacat)
+Documentation can be found [here](https://hexdocs.pm/tentacat)
 
 ## Quickstart
 


### PR DESCRIPTION
Current url leads to `https://github.com/edgurgel/tentacat/blob/master/hexdocs.pm/tentacat`