### PR TITLE
read and use additional :request_options on request!/5 

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -43,7 +43,8 @@ defmodule Tentacat do
   end
 
   def raw_request(method, url, body \\ "", headers \\ [], options \\ []) do
-    request!(method, url, body, headers, options) |> process_response
+    extra_options = Application.get_env(:tentacat, :request_options, [])
+    request!(method, url, body, headers, extra_options ++ options) |> process_response
   end
 
   @spec url(client :: Client.t, path :: binary) :: binary

--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -39,7 +39,7 @@ defmodule Tentacat do
   end
 
   def json_request(method, url, body \\ "", headers \\ [], options \\ []) do
-    request!(method, url, JSX.encode!(body), headers, options) |> process_response
+    raw_request(method, url, JSX.encode!(body), headers, options)
   end
 
   def raw_request(method, url, body \\ "", headers \\ [], options \\ []) do


### PR DESCRIPTION
This allows overriding the default options in configuration, like so:

```elixir
config :tentacat, request_options: [
    {:ssl, [
        {:cacertfile, "/etc/mysvc/mycert.pem"}
    ]}
]
```

One possible solution to issue https://github.com/edgurgel/tentacat/issues/66.  :innocent: 