### PR TITLE
Replace the use of the deprecated `Dict` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ iex> Tentacat.Users.find "edgurgel", client
 Getting info from a user without a defined client
 
 ```iex
-iex> Tentacat.Users.find("edgurgel") |> Dict.get("email")
+iex> Tentacat.Users.find("edgurgel") |> Map.get("email")
 "eduardo@gurgel.me"
 ```
 

--- a/lib/tentacat/releases.ex
+++ b/lib/tentacat/releases.ex
@@ -41,7 +41,7 @@ defmodule Tentacat.Releases do
   """
   @spec create(binary, binary, binary, Client.t, list) :: Tentacat.response
   def create(tag_name, owner, repo, client \\ %Client{}, options \\ []) when is_binary(tag_name) do
-    body = Dict.merge(options, tag_name: tag_name)
+    body = Keyword.merge(options, tag_name: tag_name)
     post "repos/#{owner}/#{repo}/releases", client, body
   end
 

--- a/lib/tentacat/releases/assets.ex
+++ b/lib/tentacat/releases/assets.ex
@@ -49,7 +49,7 @@ defmodule Tentacat.Releases.Assets do
   """
   @spec edit(binary, integer, binary, binary, Client.t, list) :: Tentacat.response
   def edit(name, id, owner, repo, client \\ %Client{}, options \\ []) when is_integer(id) do
-    body = Dict.merge(options, name: name)
+    body = Keyword.merge(options, name: name)
     patch "repos/#{owner}/#{repo}/releases/assets/#{id}", client, body
   end
 


### PR DESCRIPTION
The [`Dict`](http://elixir-lang.org/docs/stable/elixir/Dict.html) module is deprecated.