### PR TITLE
Fix Issues.Comments.update function

### DIFF
--- a/lib/tentacat/issues/comments.ex
+++ b/lib/tentacat/issues/comments.ex
@@ -109,9 +109,9 @@ defmodule Tentacat.Issues.Comments do
 
   https://developer.github.com/v3/issues/comments/#edit-a-comment
   """
-  @spec update(binary, binary, binary | integer, binary | integer, list | map, Client.t) :: Tentacat.response
-  def update(owner, repo, issue_id, comment_id, body, client \\ %Client{}) do
-    patch "repos/#{owner}/#{repo}/issues/#{issue_id}/comments/#{comment_id}", client, body
+  @spec update(binary, binary, binary | integer, list | map, Client.t) :: Tentacat.response
+  def update(owner, repo, comment_id, body, client \\ %Client{}) do
+    patch "repos/#{owner}/#{repo}/issues/comments/#{comment_id}", client, body
   end
 
   @doc """

--- a/test/fixture/vcr_cassettes/issues/comments#update.json
+++ b/test/fixture/vcr_cassettes/issues/comments#update.json
@@ -1,0 +1,45 @@
+[
+  {
+    "request": {
+      "body": "{\"body\":\"up!\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "patch",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/lest/test-repo/issues/comments/253744502"
+    },
+    "response": {
+      "body": "{\"url\":\"https://api.github.com/repos/lest/test-repo/issues/comments/253744502\",\"html_url\":\"https://github.com/lest/test-repo/pull/1#issuecomment-253744502\",\"issue_url\":\"https://api.github.com/repos/lest/test-repo/issues/1\",\"id\":253744502,\"user\":{\"login\":\"lest\",\"id\":36079,\"avatar_url\":\"https://avatars.githubusercontent.com/u/36079?v=3\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/lest\",\"html_url\":\"https://github.com/lest\",\"followers_url\":\"https://api.github.com/users/lest/followers\",\"following_url\":\"https://api.github.com/users/lest/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/lest/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/lest/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/lest/subscriptions\",\"organizations_url\":\"https://api.github.com/users/lest/orgs\",\"repos_url\":\"https://api.github.com/users/lest/repos\",\"events_url\":\"https://api.github.com/users/lest/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/lest/received_events\",\"type\":\"User\",\"site_admin\":false},\"created_at\":\"2016-10-14T08:51:14Z\",\"updated_at\":\"2016-10-14T11:07:01Z\",\"body\":\"up!\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Fri, 14 Oct 2016 11:07:01 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1151",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4991",
+        "X-RateLimit-Reset": "1476444009",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"5c3695ac6c58e49df6130b4044d4dec9\"",
+        "X-OAuth-Scopes": "repo",
+        "X-Accepted-OAuth-Scopes": "repo",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "76d9828c7e4f1d910f7ba069e90ce976",
+        "X-GitHub-Request-Id": "8611BE92:6823:BEA0AB6:5800BC55"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/issues/comments_test.exs
+++ b/test/issues/comments_test.exs
@@ -49,4 +49,12 @@ defmodule Tentacat.Issues.CommentsTest do
       assert status_code == 201
     end
   end
+
+  test "update/5" do
+    body = %{"body" => "up!"}
+    use_cassette "issues/comments#update" do
+      %{"body" => comment} = update("lest", "test-repo", 253744502, body, @client)
+      assert comment == "up!"
+    end
+  end
 end


### PR DESCRIPTION
According to [the API docs][1], the URI shouldn't include an issue
number, only a comment id:

    PATCH /repos/:owner/:repo/issues/comments/:id

[1]: https://developer.github.com/v3/issues/comments/#edit-a-comment