### PR TITLE
Allow search mudule to take options

### DIFF
--- a/lib/tentacat/search.ex
+++ b/lib/tentacat/search.ex
@@ -16,8 +16,8 @@ defmodule Tentacat.Search do
   More info at: https://developer.github.com/v3/search/#search-code
   """
   @spec code(map, Client.t) :: Tentacat.response
-  def code(params, client \\ %Client{}) do
-    get "search/code", client, params
+  def code(params, client \\ %Client{}, options \\ []) do
+    get "search/code", client, params, options
   end
 
   @doc """
@@ -31,8 +31,8 @@ defmodule Tentacat.Search do
   More info at: https://developer.github.com/v3/search/#search-users
   """
   @spec users(map, Client.t) :: Tentacat.response
-  def users(params, client \\ %Client{}) do
-    get "search/users", client, params
+  def users(params, client \\ %Client{}, options \\ []) do
+    get "search/users", client, params, options
   end
 
   @doc """
@@ -46,7 +46,7 @@ defmodule Tentacat.Search do
   More info at: https://developer.github.com/v3/search/#search-repositories
   """
   @spec repositories(map, Client.t) :: Tentacat.response
-  def repositories(params, client \\ %Client{}) do
-    get "search/repositories", client, params
+  def repositories(params, client \\ %Client{}, options \\ []) do
+    get "search/repositories", client, params, options
   end
 end

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -19,6 +19,13 @@ defmodule Tentacat.SearchTest do
     end
   end
 
+  test "code/2 with none-pagination" do
+    use_cassette "search#code" do
+      params = %{q: "code language:elixir repo:edgurgel/tentacat", sort: "url", per_page: 1}
+      assert %{"incomplete_results" => false, "items" => _} = code(params, @client, pagination: :none)
+    end
+  end
+
   test "users/2" do
     use_cassette "search#users" do
       params = %{q: "elixir-lang language:elixir", sort: "followers"}
@@ -26,10 +33,24 @@ defmodule Tentacat.SearchTest do
     end
   end
 
+  test "users/2 with none-pagination" do
+    use_cassette "search#users" do
+      params = %{q: "elixir-lang language:elixir", sort: "followers", per_page: 1}
+      assert %{"incomplete_results" => false, "items" => _} = users(params, @client, pagination: :none)
+    end
+  end
+
   test "repositories/2" do
     use_cassette "search#repositories" do
       params = %{q: "elixir-lang in:name language:elixir", sort: "stars"}
       assert %{"incomplete_results" => false, "items" => _} = repositories(params, @client)
+    end
+  end
+
+  test "repositories/2 with none-pagination" do
+    use_cassette "search#repositories" do
+      params = %{q: "elixir-lang in:name language:elixir", sort: "stars", per_page: 1}
+      assert %{"incomplete_results" => false, "items" => _} = repositories(params, @client, pagination: :none)
     end
   end
 end


### PR DESCRIPTION
https://github.com/edgurgel/tentacat/pull/70
Unexpected rate limit error occurs because of pagination and streaming in `search.ex`.
Now we can control pagination options in each functions.

```elixir
    params = %{ q: repository_name, per_page: 1 }
    options = [ pagination: :none ]
    # This code does not work because of auto streaming pagination processes with rate limits.
    # response = Tentacat.Search.repositories(params, client)

    # This code works (workaround...).
    # response = Tentacat.get "search/repositories", client, params, options

    # Now this code works (on this PR).
    response = Tentacat.Search.repositories(params, client, options)
```