### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: elixir
 elixir:
-  - 1.0.0
-  - 1.1.1
   - 1.2.0
+  - 1.3.0
 notifications:
   recipients:
     - eduardo@gurgel.me


### PR DESCRIPTION
We have HTTPoison as a dependency and it requires Elixir ~> 1.2
Also, looks like it accidentally fixed the problem with doubled messages from `coveralls` bot)