### PR TITLE
Change Tentacat.Repositories.Tags.list to support options

### DIFF
--- a/lib/tentacat/repositories/tags.ex
+++ b/lib/tentacat/repositories/tags.ex
@@ -12,7 +12,7 @@ defmodule Tentacat.Repositories.Tags do
   More info at: https://developer.github.com/v3/repos/#list-tags
   """
   @spec list(binary, binary, Client.t) :: Tentacat.response
-  def list(owner, repo, client \\ %Client{}) do
-    get "repos/#{owner}/#{repo}/tags", client
+  def list(owner, repo, client \\ %Client{}, options \\ []) do
+    get "repos/#{owner}/#{repo}/tags", client, options
   end
 end


### PR DESCRIPTION
Since Tentacat.get supports a lot of useful options like `pagination` and some resources already support passing options like https://github.com/edgurgel/tentacat/blob/v0.5.3/lib/tentacat/repositories.ex#L22
it seems like a good idea to add it to this function as well.