### PR TITLE
Add options to Search

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -51,6 +51,7 @@ defmodule Tentacat do
       client
       |> url(path)
       |> add_params_to_url(params)
+
     case pagination(options) do
       nil     -> request_stream(:get, url, client.auth) |> realize_if_needed
       :none   -> request_stream(:get, url, client.auth, "", :one_page)

--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -51,7 +51,6 @@ defmodule Tentacat do
       client
       |> url(path)
       |> add_params_to_url(params)
-IO.inspect pagination(options)
     case pagination(options) do
       nil     -> request_stream(:get, url, client.auth) |> realize_if_needed
       :none   -> request_stream(:get, url, client.auth, "", :one_page)

--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -51,7 +51,7 @@ defmodule Tentacat do
       client
       |> url(path)
       |> add_params_to_url(params)
-
+IO.inspect pagination(options)
     case pagination(options) do
       nil     -> request_stream(:get, url, client.auth) |> realize_if_needed
       :none   -> request_stream(:get, url, client.auth, "", :one_page)

--- a/lib/tentacat/search.ex
+++ b/lib/tentacat/search.ex
@@ -31,8 +31,8 @@ defmodule Tentacat.Search do
   More info at: https://developer.github.com/v3/search/#search-users
   """
   @spec users(map, Client.t) :: Tentacat.response
-  def users(params, client \\ %Client{}) do
-    get "search/users", client, params
+  def users(params, client \\ %Client{}, options \\ []) do
+    get "search/users", client, params, options
   end
 
   @doc """
@@ -46,7 +46,7 @@ defmodule Tentacat.Search do
   More info at: https://developer.github.com/v3/search/#search-repositories
   """
   @spec repositories(map, Client.t) :: Tentacat.response
-  def repositories(params, client \\ %Client{}, options \\ %{}) do
+  def repositories(params, client \\ %Client{}, options \\ [] ) do
     get "search/repositories", client, params, options
   end
 end

--- a/lib/tentacat/search.ex
+++ b/lib/tentacat/search.ex
@@ -11,7 +11,7 @@ defmodule Tentacat.Search do
   ## Example
 
       Tentacat.Search.code %{q: "code language:elixir repo:edgurgel/tentacat", sort: "url"}
-      Tentacat.Search.code %{q: "code language:elixir repo:edgurgel/tentacat", sort: "url"}, client
+      Tentacat.Search.code %{q: "code language:elixir repo:edgurgel/tentacat", sort: "url"}, client, [pagination: :none]
 
   More info at: https://developer.github.com/v3/search/#search-code
   """
@@ -26,7 +26,7 @@ defmodule Tentacat.Search do
   ## Example
 
       Tentacat.Search.users %{q: "users language:elixir", sort: "followers"}
-      Tentacat.Search.users %{q: "users language:elixir", sort: "followers"}, client
+      Tentacat.Search.users %{q: "users language:elixir", sort: "followers"}, client, [pagination: :none]
 
   More info at: https://developer.github.com/v3/search/#search-users
   """
@@ -42,6 +42,7 @@ defmodule Tentacat.Search do
 
       Tentacat.Search.repositories %{q: "elixir-lang language:elixir", sort: "stars"}
       Tentacat.Search.repositories %{q: "elixir-lang language:elixir", sort: "stars"}, client
+      Tentacat.Search.repositories %{q: "elixir-lang language:elixir", sort: "stars"}, client, [pagination: :none]
 
   More info at: https://developer.github.com/v3/search/#search-repositories
   """

--- a/lib/tentacat/search.ex
+++ b/lib/tentacat/search.ex
@@ -15,9 +15,9 @@ defmodule Tentacat.Search do
 
   More info at: https://developer.github.com/v3/search/#search-code
   """
-  @spec code(map, Client.t) :: Tentacat.response
-  def code(params, client \\ %Client{}) do
-    get "search/code", client, params
+  @spec code(map, Client.t, [atom]) :: Tentacat.response
+  def code(params, client \\ %Client{}, options \\ []) do
+    get "search/code", client, params, options
   end
 
   @doc """
@@ -30,7 +30,7 @@ defmodule Tentacat.Search do
 
   More info at: https://developer.github.com/v3/search/#search-users
   """
-  @spec users(map, Client.t) :: Tentacat.response
+  @spec users(map, Client.t, [atom]) :: Tentacat.response
   def users(params, client \\ %Client{}, options \\ []) do
     get "search/users", client, params, options
   end
@@ -45,7 +45,7 @@ defmodule Tentacat.Search do
 
   More info at: https://developer.github.com/v3/search/#search-repositories
   """
-  @spec repositories(map, Client.t) :: Tentacat.response
+  @spec repositories(map, Client.t, [atom]) :: Tentacat.response
   def repositories(params, client \\ %Client{}, options \\ [] ) do
     get "search/repositories", client, params, options
   end

--- a/lib/tentacat/search.ex
+++ b/lib/tentacat/search.ex
@@ -46,7 +46,7 @@ defmodule Tentacat.Search do
   More info at: https://developer.github.com/v3/search/#search-repositories
   """
   @spec repositories(map, Client.t) :: Tentacat.response
-  def repositories(params, client \\ %Client{}) do
-    get "search/repositories", client, params
+  def repositories(params, client \\ %Client{}, options \\ %{}) do
+    get "search/repositories", client, params, options
   end
 end

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -26,10 +26,10 @@ defmodule Tentacat.SearchTest do
     end
   end
 
-  test "repositories/2" do
+  test "repositories/3" do
     use_cassette "search#repositories" do
       params = %{q: "elixir-lang in:name language:elixir", sort: "stars"}
-      assert %{"incomplete_results" => false, "items" => _} = repositories(params, @client)
+      assert %{"incomplete_results" => false, "items" => _} = repositories(params, @client, [pagination: :none])
     end
   end
 end

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -19,10 +19,10 @@ defmodule Tentacat.SearchTest do
     end
   end
 
-  test "users/2" do
+  test "users/3" do
     use_cassette "search#users" do
       params = %{q: "elixir-lang language:elixir", sort: "followers"}
-      assert %{"incomplete_results" => false, "items" => _} = users(params, @client)
+      assert %{"incomplete_results" => false, "items" => _} = users(params, @client, [pagination: :none])
     end
   end
 

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -7,6 +7,7 @@ defmodule Tentacat.SearchTest do
   doctest Tentacat.Search
 
   @client Tentacat.Client.new
+  @options [pagination: :none]
 
   setup_all do
     HTTPoison.start
@@ -15,21 +16,21 @@ defmodule Tentacat.SearchTest do
   test "code/2" do
     use_cassette "search#code" do
       params = %{q: "code language:elixir repo:edgurgel/tentacat", sort: "url"}
-      assert %{"incomplete_results" => false, "items" => _} = code(params, @client)
+      assert %{"incomplete_results" => false, "items" => _} = code(params, @client, @options)
     end
   end
 
   test "users/3" do
     use_cassette "search#users" do
       params = %{q: "elixir-lang language:elixir", sort: "followers"}
-      assert %{"incomplete_results" => false, "items" => _} = users(params, @client, [pagination: :none])
+      assert %{"incomplete_results" => false, "items" => _} = users(params, @client, @options)
     end
   end
 
   test "repositories/3" do
     use_cassette "search#repositories" do
       params = %{q: "elixir-lang in:name language:elixir", sort: "stars"}
-      assert %{"incomplete_results" => false, "items" => _} = repositories(params, @client, [pagination: :none])
+      assert %{"incomplete_results" => false, "items" => _} = repositories(params, @client, @options)
     end
   end
 end


### PR DESCRIPTION
Currently the `Search` module does not allow you to pass options to the underlying  `Tentacat.get` function. This means that it executes searches against the Github Api with the default `pagination: :auto`, which will quickly hit rate limits on the Search API for any fairly common search term (like `language:elixir`). This PR allows options to be passed when invoking `Search`'s methods, letting the developer avoid this issue when needed.