### PR TITLE
Add API for latest Release for repository

### DIFF
--- a/lib/tentacat/releases.ex
+++ b/lib/tentacat/releases.ex
@@ -31,6 +31,21 @@ defmodule Tentacat.Releases do
   end
 
   @doc """
+  Get the latest release
+
+  ## Example
+
+      Tentacat.Releases.latest("elixir-lang", "elixir", client)
+
+  More info at: http:\\developer.github.com/v3/repos/releases/#get-the-latest-release
+
+  """
+  @spec latest(binary, binary, Client.t) :: Tentacat.response
+  def latest(owner, repo, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/releases/latest", client
+  end
+
+  @doc """
   Create a new release from the given tag
 
   ## Example

--- a/test/fixture/vcr_cassettes/releases#latest.json
+++ b/test/fixture/vcr_cassettes/releases#latest.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/releases/latest"
+    },
+    "response": {
+      "body": "{\"url\":\"https://api.github.com/repos/soudqwiggle/elixir-conspiracy/releases/2317862\",\"assets_url\":\"https://api.github.com/repos/soudqwiggle/elixir-conspiracy/releases/2317862/assets\",\"upload_url\":\"https://uploads.github.com/repos/soudqwiggle/elixir-conspiracy/releases/2317862/assets{?name,label}\",\"html_url\":\"https://github.com/soudqwiggle/elixir-conspiracy/releases/tag/v1.2\",\"id\":2317862,\"tag_name\":\"v1.2\",\"target_commitish\":\"master\",\"name\":null,\"draft\":false,\"author\":{\"login\":\"soudqwiggle\",\"id\":16187637,\"avatar_url\":\"https://avatars.githubusercontent.com/u/16187637?v=3\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/soudqwiggle\",\"html_url\":\"https://github.com/soudqwiggle\",\"followers_url\":\"https://api.github.com/users/soudqwiggle/followers\",\"following_url\":\"https://api.github.com/users/soudqwiggle/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/soudqwiggle/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/soudqwiggle/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/soudqwiggle/subscriptions\",\"organizations_url\":\"https://api.github.com/users/soudqwiggle/orgs\",\"repos_url\":\"https://api.github.com/users/soudqwiggle/repos\",\"events_url\":\"https://api.github.com/users/soudqwiggle/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/soudqwiggle/received_events\",\"type\":\"User\",\"site_admin\":false},\"prerelease\":false,\"created_at\":\"2015-12-10T21:51:01Z\",\"published_at\":\"2015-12-20T14:59:15Z\",\"assets\":[],\"tarball_url\":\"https://api.github.com/repos/soudqwiggle/elixir-conspiracy/tarball/v1.2\",\"zipball_url\":\"https://api.github.com/repos/soudqwiggle/elixir-conspiracy/zipball/v1.2\",\"body\":null}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sun, 29 Jan 2017 08:41:51 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1676",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4987",
+        "X-RateLimit-Reset": "1485680531",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"6a48fe32edfa6b591838beed6358bbd1\"",
+        "Last-Modified": "Sun, 20 Dec 2015 14:59:15 GMT",
+        "X-OAuth-Scopes": "public_repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "626ed3a9050b8faa02ef5f3c540b508d",
+        "X-GitHub-Request-Id": "F10C:4118:4109178:52A75D7:588DAACE"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/releases_test.exs
+++ b/test/releases_test.exs
@@ -24,6 +24,13 @@ defmodule Tentacat.ReleasesTest do
     end
   end
 
+  test "latest/3" do
+    use_cassette "releases#latest" do
+      %{"tag_name" => name} = latest("soudqwiggle", "elixir-conspiracy", @client)
+      assert name == "v1.2"
+    end
+  end
+
   test "create/4" do
     use_cassette "releases#create" do
       {status_code, _} = create("v1", "soudqwiggle", "elixir-conspiracy", @client)


### PR DESCRIPTION
Why:

Prior to this changeset, in order to query for the latest release for a repository a developer was required to manually construct a get API request. It would be preferable to be able to make an API request in the same manner as other API endpoints.

This change addresses the issue by:

* Adding a `latest/3` method to fetch the most recent Release for a repository