### PR TITLE
Add support for notifications API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 docs
 mix.lock
+.DS_Store

--- a/lib/tentacat/notifications.ex
+++ b/lib/tentacat/notifications.ex
@@ -1,0 +1,52 @@
+defmodule Tentacat.Notifications do
+  import Tentacat
+  alias Tentacat.Client
+
+  @moduledoc """
+  Notifications API allows to view/subscibe notifications, marking them as read and view/subscibe to threads.
+  """
+
+  @doc """
+  Get list of all notifications for the current user. Grouped by repository.
+
+  ## Example
+
+      params = %{
+        # Show notifications marked as read. Default: false
+        "all" => true,
+
+        # Only show notifications in which the user is participating or directly mentioned. Default: false
+        "participating" => true,
+
+        # Only show notifications updated after given time. Default: Time.now
+        "since" => DateTime.utc_now() |> DateTime.to_iso8601(),
+
+        # Only show notifications updated before given time.
+        "before" => DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+      Tentacat.Notifications.list(client, params)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#list-your-notifications
+  """
+  def list(client, params \\ %{}) do
+    get "notifications", client, params
+  end
+
+  @doc """
+  Mark notifications as read. If will remove them from default view on GitHub.
+
+  ## Example
+
+      params = %{
+        # Describes the last point that notifications were checked
+        "last_read_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+      Tentacat.Notifications.remove(client, params)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#mark-as-read
+  """
+  def remove(client, params \\ %{}) do
+    put "notifications", client, params
+  end
+
+end

--- a/lib/tentacat/notifications/repo.ex
+++ b/lib/tentacat/notifications/repo.ex
@@ -1,0 +1,48 @@
+defmodule Tentacat.Notifications.Repo do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  Get list of all notifications in repository for the current user.
+
+  ## Example
+
+      params = %{
+        # Show notifications marked as read. Default: false
+        "all" => true,
+
+        # Only show notifications in which the user is participating or directly mentioned. Default: false
+        "participating" => true,
+
+        # Only show notifications updated after given time. Default: Time.now
+        "since" => DateTime.utc_now() |> DateTime.to_iso8601(),
+
+        # Only show notifications updated before given time.
+        "before" => DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+      Tentacat.Notifications.Repo.list("elixir-lang", "elixir", client, params)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
+  """
+  def list(owner, repo, client, params \\ %{}) do
+    get "repos/#{owner}/#{repo}/notifications", client, params
+  end
+
+  @doc """
+  Mark notifications in repository as read. If will remove them from default view on GitHub.
+
+  ## Example
+
+      params = %{
+        # Describes the last point that notifications were checked
+        "last_read_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+      }
+      Tentacat.Notifications.Repo.remove("elixir-lang", "elixir", client, params)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
+  """
+  def remove(owner, repo, client, params \\ %{}) do
+    put "repos/#{owner}/#{repo}/notifications", client, params
+  end
+
+end

--- a/lib/tentacat/notifications/thread.ex
+++ b/lib/tentacat/notifications/thread.ex
@@ -1,0 +1,72 @@
+defmodule Tentacat.Notifications.Thread do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  View a single thread.
+
+  ## Example
+
+      Tentacat.Notifications.Thread.list(6736758, client)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#view-a-single-thread
+  """
+  def list(id, client) do
+    get "notifications/threads/#{id}", client
+  end
+
+  @doc """
+  Mark a thread as read.
+
+  ## Example
+
+      Tentacat.Notifications.Thread.remove(6736758, client)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#mark-a-thread-as-read
+  """
+  def remove(id, client) do
+    patch "notifications/threads/#{id}", client
+  end
+
+  @doc """
+  Checks if user is subscibed to thread.
+
+  ## Example
+
+      Tentacat.Notifications.Thread.subscription(6736758, client)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#get-a-thread-subscription
+  """
+  def subscription(id, client) do
+    get "notifications/threads/#{id}/subscription", client
+  end
+
+  @doc """
+  Allow user to subscibe/unsubscribe to thread.
+
+  ## Example
+      params = %{
+        # Determines if notifications should be received from this thread.
+        "subscribed" => true,
+
+        # Determines if all notifications should be blocked from this thread.
+        "igored" => true,
+
+      }
+      Tentacat.Notifications.Thread.subscribe(6736758, client, params)
+
+  More info at: https://developer.github.com/v3/activity/notifications/#set-a-thread-subscription
+  """
+  def subscribe(id, client, params \\ %{}) do
+    put "notifications/threads/#{id}/subscription", client, params
+  end
+
+  @doc """
+  Allow to delete thread subscription
+  More info at: https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
+  """
+  def delete(id, client) do
+    Tentacat.delete "notifications/threads/#{id}/subscription", client
+  end
+
+end

--- a/test/fixture/vcr_cassettes/notifications#list.json
+++ b/test/fixture/vcr_cassettes/notifications#list.json
@@ -1,0 +1,39 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token 8e663c8614ced27c09b963f806ac46776a29db50"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/notifications?"
+    },
+    "response": {
+      "body": "{\"message\":\"Bad credentials\",\"documentation_url\":\"https://developer.github.com/v3\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Fri, 17 Feb 2017 22:24:57 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "83",
+        "Status": "401 Unauthorized",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-RateLimit-Limit": "60",
+        "X-RateLimit-Remaining": "58",
+        "X-RateLimit-Reset": "1487373646",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-GitHub-Request-Id": "DFC0:1EBD2:74D43C0:96A3594:58A77839"
+      },
+      "status_code": 401,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/notifications#remove.json
+++ b/test/fixture/vcr_cassettes/notifications#remove.json
@@ -1,0 +1,39 @@
+[
+  {
+    "request": {
+      "body": "{}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token 8e663c8614ced27c09b963f806ac46776a29db50"
+      },
+      "method": "put",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/notifications"
+    },
+    "response": {
+      "body": "{\"message\":\"Bad credentials\",\"documentation_url\":\"https://developer.github.com/v3\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Fri, 17 Feb 2017 22:24:57 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "83",
+        "Status": "401 Unauthorized",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-RateLimit-Limit": "60",
+        "X-RateLimit-Remaining": "57",
+        "X-RateLimit-Reset": "1487373646",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-GitHub-Request-Id": "DFC0:1EBD2:74D43EA:96A35B5:58A77839"
+      },
+      "status_code": 401,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/notifications/repo#list.json
+++ b/test/fixture/vcr_cassettes/notifications/repo#list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token 40724b41e721fc510ceab214625d6e629d0e4c6e"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/tentatest/tentacat/notifications?"
+    },
+    "response": {
+      "body": "[]",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Fri, 17 Feb 2017 22:24:58 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4993",
+        "X-RateLimit-Reset": "1487373237",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"2badd57eda98d6ff61016a3b75931d48\"",
+        "X-Poll-Interval": "60",
+        "X-OAuth-Scopes": "notifications",
+        "X-Accepted-OAuth-Scopes": "notifications, repo",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "5aeb3f30c9e3ef6ef7bcbcddfd9a68f7",
+        "X-GitHub-Request-Id": "DFC0:1EBD2:74D440C:96A35DF:58A77839"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/notifications/repo#remove.json
+++ b/test/fixture/vcr_cassettes/notifications/repo#remove.json
@@ -1,0 +1,40 @@
+[
+  {
+    "request": {
+      "body": "{}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token 40724b41e721fc510ceab214625d6e629d0e4c6e"
+      },
+      "method": "put",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/tentatest/tentacat/notifications"
+    },
+    "response": {
+      "body": "",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Fri, 17 Feb 2017 22:24:58 GMT",
+        "Transfer-Encoding": "chunked",
+        "Status": "205 Reset Content",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4992",
+        "X-RateLimit-Reset": "1487373237",
+        "X-OAuth-Scopes": "notifications",
+        "X-Accepted-OAuth-Scopes": "notifications, repo",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-GitHub-Request-Id": "DFC0:1EBD2:74D4446:96A361C:58A7783A"
+      },
+      "status_code": 205,
+      "type": "ok"
+    }
+  }
+]

--- a/test/notifications/repo_test.exs
+++ b/test/notifications/repo_test.exs
@@ -1,0 +1,26 @@
+defmodule Tentacat.Notifications.RepoTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Notifications.Repo
+
+  doctest Tentacat.Notifications.Repo
+
+  @client Tentacat.Client.new(%{access_token: "8e663c8614ced27c09b963f806ac46776a29db50"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "list/4" do
+    use_cassette "notifications/repo#list" do
+      assert list("tentatest", "tentacat", @client) == []
+    end
+  end
+
+  test "remove/4" do
+    use_cassette "notifications/repo#remove" do
+      assert remove("tentatest", "tentacat", @client) == {205, nil}
+    end
+  end
+
+end

--- a/test/notifications_test.exs
+++ b/test/notifications_test.exs
@@ -1,0 +1,26 @@
+defmodule Tentacat.NotificationsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Notifications
+
+  doctest Tentacat.Notifications
+
+  @client Tentacat.Client.new(%{access_token: "8e663c8614ced27c09b963f806ac46776a29db50"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "list/2" do
+    use_cassette "notifications#list" do
+      assert list(@client) == []
+    end
+  end
+
+  test "remove/2" do
+    use_cassette "notifications#remove" do
+      assert remove(@client) == []
+    end
+  end
+
+end


### PR DESCRIPTION
I found that notifications is not covered in this library so I've added functions cover this part of API.

I've also tried to add tests to every new function but in seems that token used in tests has not access to notifications, or I'm doing something wrong. Also I've tried to test 'Notifications.Thread' module but I have no idea how to test. It require `thread_id` but I have no idea how to find one valid. The one used in docs is some random and official documentation uses `1` as id which returns that I have no access to this repository.

I'm novice to elixir so if someone can review this or improve my additions it would be awesome.