### PR TITLE
add support for removing a label from an issue

### DIFF
--- a/lib/tentacat/issues/labels.ex
+++ b/lib/tentacat/issues/labels.ex
@@ -29,4 +29,18 @@ defmodule Tentacat.Issues.Labels do
   def add(owner, repo, issue_id, labels, client \\ %Client{}) do
     post "repos/#{owner}/#{repo}/issues/#{issue_id}/labels", client, labels
   end
+
+  @doc """
+  Remove a label from an issue
+
+  ## Example
+
+      Tentacat.Issues.Labels.remove "elixir-lang", "elixir", 3970, "Important"
+
+  More info at: https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
+  """
+  @spec remove(binary, binary, binary | integer, binary, Client.t) :: Tentacat.response
+  def remove(owner, repo, issue_id, label, client \\ %Client{}) do
+    delete "repos/#{owner}/#{repo}/issues/#{issue_id}/labels/#{label}", client
+  end
 end

--- a/test/fixture/vcr_cassettes/issues/labels#remove.json
+++ b/test/fixture/vcr_cassettes/issues/labels#remove.json
@@ -1,0 +1,42 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/dwyl/learn-elixir/issues/1/labels/WIP"
+    },
+    "response": {
+      "body": "",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Wed, 19 Apr 2017 15:38:42 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2260",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "60",
+        "X-RateLimit-Remaining": "42",
+        "X-RateLimit-Reset": "1465314971",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"1598b9c2c9191001f30226e51a54afb2\"",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "318e55760cf7cdb40e61175a4d36cd32",
+        "X-GitHub-Request-Id": "32E9B27E:B216:239A2390:5756E46C"
+      },
+      "status_code": 204,
+      "type": "ok"
+    }
+  }
+]

--- a/test/issues/labels_test.exs
+++ b/test/issues/labels_test.exs
@@ -23,4 +23,11 @@ defmodule Tentacat.Issues.LabelsTest do
       assert name == "WIP"
     end
   end
+
+  test "remove/5" do
+    use_cassette "issues/labels#remove" do
+      {status_code, _} = remove("dwyl", "learn-elixir", "1", "WIP", @client)
+      assert status_code == 204
+    end
+  end
 end


### PR DESCRIPTION
This PR add the ```remove``` function in the ```Tentacat.Issues.Labels``` module.
see https://github.com/edgurgel/tentacat/issues/113
