### PR TITLE
Add blob support for GitHub API

### DIFF
--- a/lib/tentacat/git/blobs.ex
+++ b/lib/tentacat/git/blobs.ex
@@ -1,0 +1,39 @@
+defmodule Tentacat.Git.Blobs do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  Get the Blob content and metadata for a specific sha
+
+  ## Example
+
+      Tentacat.Git.Blobs.get "elixir-lang", "elixir", "7491bda5196f78536e5acc9b7c90a97170e4db0a"
+
+  More info at: https://developer.github.com/v3/git/blobs/#get-a-blob
+  """
+  @spec get(binary, binary, binary, Client.t) :: Tentacat.response
+  def get(owner, repo, sha, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/git/blobs/#{sha}", client
+  end
+
+  @doc """
+  Create a blob in the repository
+
+  Blob body example:
+  ```
+  %{
+    "content"   => "Content of the blob",
+    "encoding"  => "utf-8"
+  }
+  ```
+  ## Example
+
+      Tentacat.Commits.Blobs.create "elixir-lang", "elixir", blob_body
+
+  More info at: https://developer.github.com/v3/git/blobs/#create-a-blob
+  """
+  @spec create(binary, binary, map | list, Client.t) :: Tentacat.response
+  def create(owner, repo, body, client \\ %Client{}) do
+    post "repos/#{owner}/#{repo}/git/blobs", client, body
+  end
+end

--- a/test/fixture/vcr_cassettes/git/blob#create.json
+++ b/test/fixture/vcr_cassettes/git/blob#create.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "{\"content\":\"Woop!\",\"encoding\":\"utf-8\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/git/blobs"
+    },
+    "response": {
+      "body": "{\"sha\":\"d69a46d50f10c479a19bd56a066c55671180ceec\",\"url\":\"https://api.github.com/repos/soudqwiggle/elixir-conspiracy/git/blobs/d69a46d50f10c479a19bd56a066c55671180ceec\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Tue, 25 Apr 2017 00:12:40 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "159",
+        "Status": "201 Created",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4989",
+        "X-RateLimit-Reset": "1493079698",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"22d89c9984437991862ab58493859b58\"",
+        "X-OAuth-Scopes": "repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "Location": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/git/blobs/d69a46d50f10c479a19bd56a066c55671180ceec",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "a51acaae89a7607fd7ee967627be18e4",
+        "X-GitHub-Request-Id": "CC38:26DA:4340D59:53B4042:58FE9478"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/git/blob#get.json
+++ b/test/fixture/vcr_cassettes/git/blob#get.json
@@ -1,0 +1,45 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/git/blobs/d69a46d50f10c479a19bd56a066c55671180ceec"
+    },
+    "response": {
+      "body": "{\"sha\":\"d69a46d50f10c479a19bd56a066c55671180ceec\",\"size\":5,\"url\":\"https://api.github.com/repos/soudqwiggle/elixir-conspiracy/git/blobs/d69a46d50f10c479a19bd56a066c55671180ceec\",\"content\":\"V29vcCE=\\n\",\"encoding\":\"base64\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Tue, 25 Apr 2017 00:14:02 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "211",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4988",
+        "X-RateLimit-Reset": "1493079698",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"cbbbd48f4a5b34ee9a869bb024bdfa60\"",
+        "X-OAuth-Scopes": "repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "7b641bda7ec2ca7cd9df72d2578baf75",
+        "X-GitHub-Request-Id": "D737:26D8:42F11AB:538E302:58FE94CA"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/git/blobs_test.exs
+++ b/test/git/blobs_test.exs
@@ -1,0 +1,31 @@
+defmodule Tentacat.Git.BlobsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Git.Blobs
+
+  doctest Tentacat.Git.Blobs
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "create/3" do
+    use_cassette "git/blob#create" do
+      body = %{
+        "content" => "Woop!",
+        "encoding" => "utf-8"
+      }
+      { 201, %{"sha" => sha}} = create("soudqwiggle", "elixir-conspiracy", body, @client)
+      assert sha == "d69a46d50f10c479a19bd56a066c55671180ceec"
+    end
+  end
+
+  test "get/4" do
+    use_cassette "git/blob#get" do
+      sha = "d69a46d50f10c479a19bd56a066c55671180ceec"
+      assert get("soudqwiggle", "elixir-conspiracy", sha, @client) |> Map.get("sha") == sha
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 ExUnit.start
 ExVCR.Config.cassette_library_dir("test/fixture/vcr_cassettes")
+ExVCR.Config.filter_sensitive_data("token [^\"]+", "token yourtokencomeshere")


### PR DESCRIPTION
Adding [Git Blob](https://developer.github.com/v3/git/blobs/#custom-media-types) support.

Also adds a configuration to automatically strip the authentication tokens from cassettes when they're created.