### PR TITLE
Removed compile warnings

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -84,7 +84,7 @@ defmodule Tentacat do
 
   def raw_request(method, url, body \\ "", headers \\ [], options \\ []) do
     method
-    |> request!(url, body, extra_headers ++ headers, extra_options ++ options)
+    |> request!(url, body, extra_headers() ++ headers, extra_options() ++ options)
     |> process_response
   end
 
@@ -119,7 +119,7 @@ defmodule Tentacat do
 
   @spec request_with_pagination(atom, binary, Client.auth, binary) :: {binary, binary, Client.auth}
   def request_with_pagination(method, url, auth, body \\ "") do
-    resp = request!(method, url, JSX.encode!(body), authorization_header(auth, extra_headers ++ @user_agent), extra_options)
+    resp = request!(method, url, JSX.encode!(body), authorization_header(auth, extra_headers() ++ @user_agent), extra_options())
     case process_response(resp) do
       x when is_tuple(x) -> x
       _ -> pagination_tuple(resp, auth)

--- a/mix.exs
+++ b/mix.exs
@@ -11,10 +11,10 @@ defmodule Tentacat.Mixfile do
       elixir: "~> 1.0",
       name: "Tentacat",
       description: @description,
-      package: package,
+      package: package(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test],
-      deps: deps ]
+      deps: deps() ]
   end
 
   def application do


### PR DESCRIPTION
The warnings were annoying me :P
```==> tentacat
Compiling 44 files (.ex)
warning: variable "extra_headers" does not exist and is being expanded to "extra_headers()", please use parentheses to remove the ambiguity or change the variable name
  lib/tentacat.ex:87

warning: variable "extra_options" does not exist and is being expanded to "extra_options()", please use parentheses to remove the ambiguity or change the variable name
  lib/tentacat.ex:87

warning: variable "extra_headers" does not exist and is being expanded to "extra_headers()", please use parentheses to remove the ambiguity or change the variable name
  lib/tentacat.ex:122

warning: variable "extra_options" does not exist and is being expanded to "extra_options()", please use parentheses to remove the ambiguity or change the variable name
  lib/tentacat.ex:122

Generated tentacat app```