### PR TITLE
Handling GitHub Redirects

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -121,7 +121,7 @@ defmodule Tentacat do
   def request_with_pagination(method, url, auth, body \\ "") do
     resp = request!(method, url, JSX.encode!(body), authorization_header(auth, extra_headers() ++ @user_agent), extra_options())
     case process_response(resp) do
-        {status, redirect_response} when status in [301, 302, 307] -> redirect_response
+      {status, _} when status in [301, 302, 307] ->
         request_with_pagination(method, location_header(resp), auth)
       x when is_tuple(x) -> x
       _ -> pagination_tuple(resp, auth)

--- a/test/fixture/vcr_cassettes/members#member_.json
+++ b/test/fixture/vcr_cassettes/members#member_.json
@@ -38,5 +38,45 @@
       "status_code": 302,
       "type": "ok"
     }
+  },
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/organizations/5861005/public_members/josephwilk"
+    },
+    "response": {
+      "body": "{\"message\":\"User does not exist or is not a public member of the organization\",\"documentation_url\":\"https://developer.github.com/v3/orgs/members/#check-public-membership\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Fri, 11 Dec 2015 21:36:42 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "171",
+        "Status": "404 Not Found",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4997",
+        "X-RateLimit-Reset": "1449873118",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Frame-Options": "deny",
+        "Content-Security-Policy": "default-src 'none'",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-GitHub-Request-Id": "5F5BF349:134F4:6BA647F:566B41EA"
+      },
+      "status_code": 404,
+      "type": "ok"
+    }
   }
 ]

--- a/test/organizations/members_test.exs
+++ b/test/organizations/members_test.exs
@@ -20,7 +20,8 @@ defmodule Tentacat.Organizations.MembersTest do
 
   test "member?/3" do
     use_cassette "members#member_" do
-      assert member?("elixir-conspiracy", "josephwilk", @client) == {302, nil}
+      {status_code, _} = member?("elixir-conspiracy", "josephwilk", @client)
+      assert status_code == 404
     end
   end
 


### PR DESCRIPTION
Issue: #121 

Github can return redirect responses in some cases like when a repository is renamed, this PR will address that by handling 301, 302 and 307 responses which are documented [here](https://developer.github.com/v3/#http-redirects)
