### PR TITLE
Update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: elixir
-elixir:
-  - 1.2.0
-  - 1.3.0
+matrix:
+  include:
+    - otp_release: 18.3
+      elixir: 1.3
+    - otp_release: 19.3
+      elixir: 1.3
+    - otp_release: 18.3
+      elixir: 1.4
+    - otp_release: 19.3
+      elixir: 1.4
+    - otp_release: 20.0
+      elixir: 1.4
+    - otp_release: 19.3
+      elixir: 1.5
+    - otp_release: 20.0
+      elixir: 1.5
 notifications:
   recipients:
     - eduardo@gurgel.me
-otp_release:
-  - 18.2
 env:
   - MIX_ENV=test
 script:


### PR DESCRIPTION
Add more OTP and Elixir versions to travis matrix.

I don't know how far do you want to be backward compatible, but imo we can remove elixir 1.2.6