### PR TITLE
Add minimal support for GitHub Installations API

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -217,6 +217,7 @@ defmodule Tentacat do
 
     * Basic authentication
     * OAuth2 Token
+    * JWT
 
   This function accepts both.
 
@@ -227,6 +228,9 @@ defmodule Tentacat do
 
       iex> Tentacat.authorization_header(%{access_token: "92873971893"}, [])
       [{"Authorization", "token 92873971893"}]
+
+      iex> Tentacat.authorization_header(%{jwt: "92873971893"}, [])
+      [{"Authorization", "Bearer 92873971893"}]
 
   ## More info
   http:\\developer.github.com/v3/#authentication
@@ -239,6 +243,10 @@ defmodule Tentacat do
 
   def authorization_header(%{access_token: token}, headers) do
     headers ++ [{"Authorization", "token #{token}"}]
+  end
+
+  def authorization_header(%{jwt: jwt}, headers) do
+    headers ++ [{"Authorization", "Bearer #{jwt}"}]
   end
 
   def authorization_header(_, headers), do: headers

--- a/lib/tentacat/app.ex
+++ b/lib/tentacat/app.ex
@@ -1,0 +1,19 @@
+defmodule Tentacat.App do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  Get info for the authorized app
+
+  ## Example
+
+      Tentacat.App.me client
+
+  More info at: https://developer.github.com/v3/apps/#get-the-authenticated-github-app
+  """
+  @spec me(Client.t) :: Tentacat.response
+  def me(client) do
+    get "app", client
+  end
+
+end

--- a/lib/tentacat/app/installations.ex
+++ b/lib/tentacat/app/installations.ex
@@ -1,0 +1,47 @@
+defmodule Tentacat.App.Installations do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  List installations for the authorized app
+
+  ## Example
+
+      Tentacat.App.Installations.list_mine client
+
+  More info at: https://developer.github.com/v3/apps/#find-installations
+  """
+  @spec list_mine(Client.t) :: Tentacat.response
+  def list_mine(client) do
+    get "app/installations", client
+  end
+
+  @doc """
+  Get a specific installation
+
+  ## Example
+
+      Tentacat.App.Installations.find 12, client
+
+  More info at: https://developer.github.com/v3/apps/#get-a-single-installation
+  """
+  @spec find(integer, Client.t) :: Tentacat.response
+  def find(installation_id, client) do
+    get "app/installations/#{installation_id}", client
+  end
+
+  @doc """
+  Get an authorization token for an installation
+
+  ## Example
+
+      Tentacat.App.Installations.token 12, client
+
+  More info at: https://developer.github.com/v3/apps/#create-a-new-installation-token
+  """
+  @spec token(integer, Client.t) :: Tentacat.response
+  def token(installation_id, client) do
+    post "app/installations/#{installation_id}/access_tokens", client
+  end
+
+end

--- a/test/app/installations_test.exs
+++ b/test/app/installations_test.exs
@@ -1,0 +1,33 @@
+defmodule Tentacat.App.InstallationsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.App.Installations
+
+  doctest Tentacat.App.Installations
+
+  @client Tentacat.Client.new(%{jwt: "your.jwt.here"})
+
+  setup_all do
+    Application.put_env :tentacat, :extra_headers, [{"Accept", "application/vnd.github.machine-man-preview+json"}]
+    ExVCR.Config.filter_request_headers "Authorization"
+    HTTPoison.start
+  end
+
+  test "list_mine/1" do
+    use_cassette "app/installations#list_mine" do
+      assert length(list_mine(@client)) == 1
+    end
+  end
+
+  test "find/2" do
+    use_cassette "app/installations#find" do
+      assert find(66216, @client)["id"] == 66216
+    end
+  end
+
+  test "token/2" do
+    use_cassette "app/installations#token" do
+      assert elem(token(66216, @client), 1)["token"] == "v1.b328f705dbba381a0f61697986a8faa09dacb097"
+    end
+  end
+end

--- a/test/app_test.exs
+++ b/test/app_test.exs
@@ -1,0 +1,21 @@
+defmodule Tentacat.AppTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.App
+
+  doctest Tentacat.App
+
+  @client Tentacat.Client.new(%{jwt: "your.jwt.here"})
+
+  setup_all do
+    Application.put_env :tentacat, :extra_headers, [{"Accept", "application/vnd.github.machine-man-preview+json"}]
+    ExVCR.Config.filter_request_headers "Authorization"
+    HTTPoison.start
+  end
+
+  test "me/1" do
+    use_cassette "app#me" do
+      assert me(@client)["name"] == "tentacatty"
+    end
+  end
+end

--- a/test/fixture/vcr_cassettes/app#me.json
+++ b/test/fixture/vcr_cassettes/app#me.json
@@ -1,0 +1,41 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat",
+        "Authorization": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/app"
+    },
+    "response": {
+      "body": "{\"id\":6615,\"owner\":{\"login\":\"outofambit\",\"id\":964912,\"avatar_url\":\"https://avatars3.githubusercontent.com/u/964912?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/outofambit\",\"html_url\":\"https://github.com/outofambit\",\"followers_url\":\"https://api.github.com/users/outofambit/followers\",\"following_url\":\"https://api.github.com/users/outofambit/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/outofambit/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/outofambit/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/outofambit/subscriptions\",\"organizations_url\":\"https://api.github.com/users/outofambit/orgs\",\"repos_url\":\"https://api.github.com/users/outofambit/repos\",\"events_url\":\"https://api.github.com/users/outofambit/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/outofambit/received_events\",\"type\":\"User\",\"site_admin\":false},\"name\":\"tentacatty\",\"description\":\"\",\"external_url\":\"https://github.com/outofambit/tentacat\",\"html_url\":\"https://github.com/apps/tentacatty\",\"created_at\":\"2017-11-09T21:10:27Z\",\"updated_at\":\"2017-11-09T21:10:27Z\"}",
+      "headers": {
+        "Date": "Thu, 09 Nov 2017 21:14:14 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1128",
+        "Server": "GitHub.com",
+        "Status": "200 OK",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"83692d979858f8db37b5639efc69b395\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.021745",
+        "X-GitHub-Request-Id": "F01E:72D6:127AFAE:15BE582:5A04C526"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/app/installations#find.json
+++ b/test/fixture/vcr_cassettes/app/installations#find.json
@@ -1,0 +1,41 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat",
+        "Authorization": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/app/installations/66216"
+    },
+    "response": {
+      "body": "{\"id\":66216,\"account\":{\"login\":\"outofambit\",\"id\":964912,\"avatar_url\":\"https://avatars3.githubusercontent.com/u/964912?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/outofambit\",\"html_url\":\"https://github.com/outofambit\",\"followers_url\":\"https://api.github.com/users/outofambit/followers\",\"following_url\":\"https://api.github.com/users/outofambit/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/outofambit/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/outofambit/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/outofambit/subscriptions\",\"organizations_url\":\"https://api.github.com/users/outofambit/orgs\",\"repos_url\":\"https://api.github.com/users/outofambit/repos\",\"events_url\":\"https://api.github.com/users/outofambit/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/outofambit/received_events\",\"type\":\"User\",\"site_admin\":false},\"repository_selection\":\"selected\",\"access_tokens_url\":\"https://api.github.com/installations/66216/access_tokens\",\"repositories_url\":\"https://api.github.com/installation/repositories\",\"html_url\":\"https://github.com/settings/installations/66216\",\"integration_id\":6615,\"app_id\":6615,\"target_id\":964912,\"target_type\":\"User\",\"permissions\":{\"metadata\":\"read\"},\"events\":[],\"created_at\":\"2017-11-09T21:54:50Z\",\"updated_at\":\"2017-11-09T21:54:50Z\",\"single_file_name\":null}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Thu, 09 Nov 2017 22:05:38 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1380",
+        "Status": "200 OK",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"909595e96ffd5c9063f76c109f74afd2\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.029284",
+        "X-GitHub-Request-Id": "F9F4:7E2F:1E01F42:3F34165:5A04D132"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/app/installations#list_mine.json
+++ b/test/fixture/vcr_cassettes/app/installations#list_mine.json
@@ -1,0 +1,41 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat",
+        "Authorization": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/app/installations"
+    },
+    "response": {
+      "body": "[{\"id\":66216,\"account\":{\"login\":\"outofambit\",\"id\":964912,\"avatar_url\":\"https://avatars3.githubusercontent.com/u/964912?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/outofambit\",\"html_url\":\"https://github.com/outofambit\",\"followers_url\":\"https://api.github.com/users/outofambit/followers\",\"following_url\":\"https://api.github.com/users/outofambit/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/outofambit/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/outofambit/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/outofambit/subscriptions\",\"organizations_url\":\"https://api.github.com/users/outofambit/orgs\",\"repos_url\":\"https://api.github.com/users/outofambit/repos\",\"events_url\":\"https://api.github.com/users/outofambit/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/outofambit/received_events\",\"type\":\"User\",\"site_admin\":false},\"repository_selection\":\"selected\",\"access_tokens_url\":\"https://api.github.com/installations/66216/access_tokens\",\"repositories_url\":\"https://api.github.com/installation/repositories\",\"html_url\":\"https://github.com/settings/installations/66216\",\"integration_id\":6615,\"app_id\":6615,\"target_id\":964912,\"target_type\":\"User\",\"permissions\":{\"metadata\":\"read\"},\"events\":[],\"created_at\":\"2017-11-09T21:54:50Z\",\"updated_at\":\"2017-11-09T21:54:50Z\",\"single_file_name\":null}]",
+      "headers": {
+        "Date": "Thu, 09 Nov 2017 21:57:19 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1382",
+        "Server": "GitHub.com",
+        "Status": "200 OK",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"2ff98ebb92e5357b5d533fd71af8618f\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.039917",
+        "X-GitHub-Request-Id": "F71C:72D5:49A8988:5667752:5A04CF3E"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/app/installations#token.json
+++ b/test/fixture/vcr_cassettes/app/installations#token.json
@@ -1,0 +1,41 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat",
+        "Authorization": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/app/installations/66216/access_tokens"
+    },
+    "response": {
+      "body": "{\"token\":\"v1.b328f705dbba381a0f61697986a8faa09dacb097\",\"expires_at\":\"2017-11-09T23:05:38Z\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Thu, 09 Nov 2017 22:05:38 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "91",
+        "Status": "201 Created",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"408e36ae56a33785fdb034fdb9e41a22\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.019062",
+        "X-GitHub-Request-Id": "F9F4:7E2F:1E01F59:3F34178:5A04D132"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/tentacat_test.exs
+++ b/test/tentacat_test.exs
@@ -20,6 +20,11 @@ defmodule TentacatTest do
     assert authorization_header(%{access_token: "9820103"}, []) == [{"Authorization", "token 9820103"}]
   end
 
+  test "authorization_header using jwt" do
+    jwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE"
+    assert authorization_header(%{jwt: jwt}, []) == [{"Authorization", "Bearer #{jwt}"}]
+  end
+
   test "process response on a 200 response" do
     assert process_response(%HTTPoison.Response{ status_code: 200,
                                                  headers: %{},


### PR DESCRIPTION
Added necessary components to use this library with the GitHub Apps and Installations API. There's enough here to authorize as an installation, do some basic installations querying, and get an auth token for a specific installation.

Includes:
* support for JWT authorization headers (and thus, clients)
* minimal coverage of `app` API
* minimal coverage of `installations` API

Happy to make changes based on feedback so let me know what you think!