### PR TITLE
Add support for the Reactions APIs

### DIFF
--- a/lib/tentacat/comments/reactions.ex
+++ b/lib/tentacat/comments/reactions.ex
@@ -1,0 +1,35 @@
+defmodule Tentacat.Comments.Reactions do
+  import Tentacat
+
+  alias Tentacat.Client
+
+  @doc """
+  List the reactions on a comment
+
+  ## Example
+
+  Tentacat.Comments.Reactions.list "elixir-lang" , "elixir", "345434"
+
+  More info at: https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
+  """
+  @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
+  def list(owner, repo, comment_id, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/comments/#{comment_id}/reactions", client
+  end
+
+  @doc """
+  Create a reaction on a comment
+
+  Reaction Request body example:
+      %{ content: "heart" }
+
+  ### Example
+
+  Tentacat.Comments.Reactions.create "elixir-lang", "elixir", "345434"
+  More info at: https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
+  """
+  @spec create(binary, binary, binary | integer, Keyword.t | map, Client.t) :: Tentacat.response
+  def create(owner, repo, comment_id, body, client \\ %Client{}) do
+    post "repos/#{owner}/#{repo}/comments/#{comment_id}/reactions", client, body
+  end
+end

--- a/lib/tentacat/issues/comments/reactions.ex
+++ b/lib/tentacat/issues/comments/reactions.ex
@@ -1,0 +1,38 @@
+defmodule Tentacat.Issues.Comments.Reactions do
+  import Tentacat
+
+  alias Tentacat.Client
+
+  @doc """
+  List the reactions on an issue comment
+
+  ## Example
+
+  Tentacat.Issues.Comments.Reactions.list "elixir-lang" , "elixir", "3"
+
+  More info at: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+  """
+
+  @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
+  def list(owner, repo, comment_id, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/issues/comments/#{comment_id}/reactions", client
+  end
+
+  @doc """
+  Create a reaction on an issue comment
+
+  Reaction Request body example:
+      %{ content: "heart" }
+
+
+  ### Example
+
+  Tentacat.Issues.Comments.Reactions.create "elixir-lang", "elixir", "3", %{ content: "heart" }, client
+
+  More info at: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+  """
+  @spec create(binary, binary, binary | integer, Keyword.t | map, Client.t) :: Tentacat.response
+  def create(owner, repo, comment_id, body, client \\ %Client{}) do
+    post "repos/#{owner}/#{repo}/issues/comments/#{comment_id}/reactions", client, body
+  end
+end

--- a/lib/tentacat/issues/reactions.ex
+++ b/lib/tentacat/issues/reactions.ex
@@ -1,0 +1,38 @@
+defmodule Tentacat.Issues.Reactions do
+  import Tentacat
+
+  alias Tentacat.Client
+
+  @doc """
+  List the reactions on a issue
+
+  ## Example
+
+  Tentacat.Issues.Reactions.list "elixir-lang" , "elixir", "3"
+
+  More info at: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
+  """
+
+  @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
+  def list(owner, repo, issue_id, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/issues/#{issue_id}/reactions", client
+  end
+
+  @doc """
+  Create a reaction on an issue
+
+  Reaction Request body example:
+      %{ content: "heart" }
+
+
+  ### Example
+
+  Tentacat.Reactions.Issues.create "elixir-lang", "elixir", "3"
+
+  More info at: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
+  """
+  @spec create(binary, binary, binary | integer, Keyword.t | map, Client.t) :: Tentacat.response
+  def create(owner, repo, issue_id, body, client \\ %Client{}) do
+    post "repos/#{owner}/#{repo}/issues/#{issue_id}/reactions", client, body
+  end
+end

--- a/lib/tentacat/issues/reactions.ex
+++ b/lib/tentacat/issues/reactions.ex
@@ -27,7 +27,7 @@ defmodule Tentacat.Issues.Reactions do
 
   ### Example
 
-  Tentacat.Reactions.Issues.create "elixir-lang", "elixir", "3"
+  Tentacat.Issues.Reactions.create "elixir-lang", "elixir", "3"
 
   More info at: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
   """

--- a/lib/tentacat/pulls/comments/reactions.ex
+++ b/lib/tentacat/pulls/comments/reactions.ex
@@ -1,0 +1,38 @@
+defmodule Tentacat.Pulls.Comments.Reactions do
+  import Tentacat
+
+  alias Tentacat.Client
+
+  @doc """
+  List the reactions on a issue
+
+  ## Example
+
+  Tentacat.Pulls.Comments.Reactions.list "elixir-lang" , "elixir", "3"
+
+  More info at: https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment
+  """
+
+  @spec list(binary, binary, binary | integer, Client.t) :: Tentacat.response
+  def list(owner, repo, comment_id, client \\ %Client{}) do
+    get "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}/reactions", client
+  end
+
+  @doc """
+  Create a reaction on an issue
+
+  Reaction Request body example:
+      %{ content: "heart" }
+
+
+  ### Example
+
+  Tentacat.Pulls.Comments.Reactions.create "elixir-lang", "elixir", "3"
+
+  More info at: https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment
+  """
+  @spec create(binary, binary, binary | integer, Keyword.t | map, Client.t) :: Tentacat.response
+  def create(owner, repo, comment_id, body, client \\ %Client{}) do
+    post "repos/#{owner}/#{repo}/pulls/comments/#{comment_id}/reactions", client, body
+  end
+end

--- a/lib/tentacat/reactions.ex
+++ b/lib/tentacat/reactions.ex
@@ -1,0 +1,20 @@
+defmodule Tentacat.Reactions do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  Delete a reaction
+
+  ## Example
+
+      Tentacat.Reactions.delete("elixir-lang", "elixir", client, reaction_id)
+
+
+  More info at: https://developer.github.com/v3/reactions/#delete-a-reaction
+  """
+
+  @spec delete(integer, binary, Client.t) :: Tentacat.response
+  def delete(id, owner, repo, client \\ %Client{}) when is_integer(id) do
+    delete "repos/#{owner}/#{repo}/releases/#{id}", client
+  end
+end

--- a/test/comments/reactions_test.exs
+++ b/test/comments/reactions_test.exs
@@ -1,0 +1,29 @@
+defmodule Tentacat.Comments.ReactionsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Comments.Reactions
+
+  doctest Tentacat.Comments.Reactions
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "list/4" do
+    use_cassette "comments/reactions#list" do
+      assert list("soudqwiggle", "elixir-conspiracy", "1", @client) == []
+    end
+  end
+
+  test "create/5" do
+    body = %{
+      "content" => "heart",
+    }
+    use_cassette "comments/reactions#create" do
+      {status_code, _} = create("soudqwiggle", "elixir-conspiracy", "1", body, @client)
+      assert status_code == 201
+    end
+  end
+end

--- a/test/fixture/vcr_cassettes/comments/reactions#create.json
+++ b/test/fixture/vcr_cassettes/comments/reactions#create.json
@@ -1,0 +1,47 @@
+[
+  {
+    "request": {
+      "body": "{\"content\":\"heart\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/comments/1/reactions"
+    },
+    "response": {
+      "body": "{\"url\":\"https://api.github.com/orgs/tentatest/hooks/6736758\",\"test_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/test\",\"ping_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/pings\",\"id\":6736758,\"name\":\"web\",\"active\":true,\"events\":[\"push\",\"pull_request\"],\"config\":{\"content_type\":\"json\",\"url\":\"http://example.com/webhook\"},\"last_response\":{\"code\":null,\"status\":\"unused\",\"message\":null},\"updated_at\":\"2015-12-19T07:25:49Z\",\"created_at\":\"2015-12-19T07:25:49Z\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sat, 19 Dec 2015 07:25:49 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "541",
+        "Status": "201 Created",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4986",
+        "X-RateLimit-Reset": "1450510991",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"71ae880155e3d5dbd6f503ae50fb77c4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "admin:repo_hook, public_repo, repo, write:repo_hook",
+        "Location": "https://api.github.com/orgs/tentatest/hooks/6736758",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "cee4c0729c8e9147e7abcb45b9d69689",
+        "X-GitHub-Request-Id": "3E552BA7:134F5:C7071D7:5675067D"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/comments/reactions#list.json
+++ b/test/fixture/vcr_cassettes/comments/reactions#list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/comments/1/reactions"
+    },
+    "response": {
+      "body": "[]",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sun, 13 Dec 2015 21:04:06 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4995",
+        "X-RateLimit-Reset": "1450042488",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"411634914830e1b11d359df5aeb17ed4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Frame-Options": "deny",
+        "Content-Security-Policy": "default-src 'none'",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Served-By": "a6882e5cd2513376cb9481dbcd83f3a2",
+        "X-GitHub-Request-Id": "4E549DF0:A39A:88313C0:566DDD45"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/issues/comments/reactions#create.json
+++ b/test/fixture/vcr_cassettes/issues/comments/reactions#create.json
@@ -1,0 +1,47 @@
+[
+  {
+    "request": {
+      "body": "{\"content\":\"heart\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/issues/comments/1/reactions"
+    },
+    "response": {
+      "body": "{\"url\":\"https://api.github.com/orgs/tentatest/hooks/6736758\",\"test_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/test\",\"ping_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/pings\",\"id\":6736758,\"name\":\"web\",\"active\":true,\"events\":[\"push\",\"pull_request\"],\"config\":{\"content_type\":\"json\",\"url\":\"http://example.com/webhook\"},\"last_response\":{\"code\":null,\"status\":\"unused\",\"message\":null},\"updated_at\":\"2015-12-19T07:25:49Z\",\"created_at\":\"2015-12-19T07:25:49Z\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sat, 19 Dec 2015 07:25:49 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "541",
+        "Status": "201 Created",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4986",
+        "X-RateLimit-Reset": "1450510991",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"71ae880155e3d5dbd6f503ae50fb77c4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "admin:repo_hook, public_repo, repo, write:repo_hook",
+        "Location": "https://api.github.com/orgs/tentatest/hooks/6736758",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "cee4c0729c8e9147e7abcb45b9d69689",
+        "X-GitHub-Request-Id": "3E552BA7:134F5:C7071D7:5675067D"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/issues/comments/reactions#list.json
+++ b/test/fixture/vcr_cassettes/issues/comments/reactions#list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/issues/comments/1/reactions"
+    },
+    "response": {
+      "body": "[]",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sun, 13 Dec 2015 21:04:06 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4995",
+        "X-RateLimit-Reset": "1450042488",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"411634914830e1b11d359df5aeb17ed4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Frame-Options": "deny",
+        "Content-Security-Policy": "default-src 'none'",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Served-By": "a6882e5cd2513376cb9481dbcd83f3a2",
+        "X-GitHub-Request-Id": "4E549DF0:A39A:88313C0:566DDD45"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/issues/reactions#create.json
+++ b/test/fixture/vcr_cassettes/issues/reactions#create.json
@@ -1,0 +1,47 @@
+[
+  {
+    "request": {
+      "body": "{\"content\":\"heart\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/issues/1/reactions"
+    },
+    "response": {
+      "body": "{\"url\":\"https://api.github.com/orgs/tentatest/hooks/6736758\",\"test_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/test\",\"ping_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/pings\",\"id\":6736758,\"name\":\"web\",\"active\":true,\"events\":[\"push\",\"pull_request\"],\"config\":{\"content_type\":\"json\",\"url\":\"http://example.com/webhook\"},\"last_response\":{\"code\":null,\"status\":\"unused\",\"message\":null},\"updated_at\":\"2015-12-19T07:25:49Z\",\"created_at\":\"2015-12-19T07:25:49Z\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sat, 19 Dec 2015 07:25:49 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "541",
+        "Status": "201 Created",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4986",
+        "X-RateLimit-Reset": "1450510991",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"71ae880155e3d5dbd6f503ae50fb77c4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "admin:repo_hook, public_repo, repo, write:repo_hook",
+        "Location": "https://api.github.com/orgs/tentatest/hooks/6736758",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "cee4c0729c8e9147e7abcb45b9d69689",
+        "X-GitHub-Request-Id": "3E552BA7:134F5:C7071D7:5675067D"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/issues/reactions#list.json
+++ b/test/fixture/vcr_cassettes/issues/reactions#list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/issues/1/reactions"
+    },
+    "response": {
+      "body": "[]",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sun, 13 Dec 2015 21:04:06 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4995",
+        "X-RateLimit-Reset": "1450042488",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"411634914830e1b11d359df5aeb17ed4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Frame-Options": "deny",
+        "Content-Security-Policy": "default-src 'none'",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Served-By": "a6882e5cd2513376cb9481dbcd83f3a2",
+        "X-GitHub-Request-Id": "4E549DF0:A39A:88313C0:566DDD45"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/pulls/comments/reactions#create.json
+++ b/test/fixture/vcr_cassettes/pulls/comments/reactions#create.json
@@ -1,0 +1,47 @@
+[
+  {
+    "request": {
+      "body": "{\"content\":\"heart\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/pulls/comments/1/reactions"
+    },
+    "response": {
+      "body": "{\"url\":\"https://api.github.com/orgs/tentatest/hooks/6736758\",\"test_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/test\",\"ping_url\":\"https://api.github.com/orgs/tentatest/hooks/6736758/pings\",\"id\":6736758,\"name\":\"web\",\"active\":true,\"events\":[\"push\",\"pull_request\"],\"config\":{\"content_type\":\"json\",\"url\":\"http://example.com/webhook\"},\"last_response\":{\"code\":null,\"status\":\"unused\",\"message\":null},\"updated_at\":\"2015-12-19T07:25:49Z\",\"created_at\":\"2015-12-19T07:25:49Z\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sat, 19 Dec 2015 07:25:49 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "541",
+        "Status": "201 Created",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4986",
+        "X-RateLimit-Reset": "1450510991",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"71ae880155e3d5dbd6f503ae50fb77c4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "admin:repo_hook, public_repo, repo, write:repo_hook",
+        "Location": "https://api.github.com/orgs/tentatest/hooks/6736758",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "cee4c0729c8e9147e7abcb45b9d69689",
+        "X-GitHub-Request-Id": "3E552BA7:134F5:C7071D7:5675067D"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/pulls/comments/reactions#list.json
+++ b/test/fixture/vcr_cassettes/pulls/comments/reactions#list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/pulls/comments/1/reactions"
+    },
+    "response": {
+      "body": "[]",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sun, 13 Dec 2015 21:04:06 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4995",
+        "X-RateLimit-Reset": "1450042488",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "ETag": "\"411634914830e1b11d359df5aeb17ed4\"",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Frame-Options": "deny",
+        "Content-Security-Policy": "default-src 'none'",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Served-By": "a6882e5cd2513376cb9481dbcd83f3a2",
+        "X-GitHub-Request-Id": "4E549DF0:A39A:88313C0:566DDD45"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/reactions#delete.json
+++ b/test/fixture/vcr_cassettes/reactions#delete.json
@@ -1,0 +1,42 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/soudqwiggle/elixir-conspiracy/releases/2317708"
+    },
+    "response": {
+      "body": "",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Sun, 20 Dec 2015 13:44:07 GMT",
+        "Status": "204 No Content",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4987",
+        "X-RateLimit-Reset": "1450620335",
+        "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "Vary": "Accept-Encoding",
+        "X-Served-By": "13d09b732ebe76f892093130dc088652",
+        "X-GitHub-Request-Id": "3E552BA7:A39B:14A1D46D:5676B0A7"
+      },
+      "status_code": 204,
+      "type": "ok"
+    }
+  }
+]

--- a/test/issues/comments/reactions_test.exs
+++ b/test/issues/comments/reactions_test.exs
@@ -1,0 +1,29 @@
+defmodule Tentacat.Issues.Comments.ReactionsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Issues.Comments.Reactions
+
+  doctest Tentacat.Issues.Comments.Reactions
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "list/4" do
+    use_cassette "issues/comments/reactions#list" do
+      assert list("soudqwiggle", "elixir-conspiracy", "1", @client) == []
+    end
+  end
+
+  test "create/5" do
+    body = %{
+      "content" => ":+1:",
+    }
+    use_cassette "issues/comments/reactions#create" do
+      {status_code, _} = create("soudqwiggle", "elixir-conspiracy", "1", body, @client)
+      assert status_code == 201
+    end
+  end
+end

--- a/test/issues/reactions_test.ex
+++ b/test/issues/reactions_test.ex
@@ -1,0 +1,29 @@
+defmodule Tentacat.Issues.ReactionsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Issues.Reactions
+
+  doctest Tentacat.Issues.Reactions
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "list/4" do
+    use_cassette "issues/reactions#list" do
+      assert list("soudqwiggle", "elixir-conspiracy", "1", @client) == []
+    end
+  end
+
+  test "create/5" do
+    body = %{
+      "content" => ":+1:",
+    }
+    use_cassette "issues/reactions#create" do
+      {status_code, _} = create("soudqwiggle", "elixir-conspiracy", "1", body, @client)
+      assert status_code == 201
+    end
+  end
+end

--- a/test/pulls/comments/reactions_test.exs
+++ b/test/pulls/comments/reactions_test.exs
@@ -1,0 +1,29 @@
+defmodule Tentacat.Pulls.Comments.ReactionsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Pulls.Comments.Reactions
+
+  doctest Tentacat.Pulls.Comments.Reactions
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "list/4" do
+    use_cassette "pulls/comments/reactions#list" do
+      assert list("soudqwiggle", "elixir-conspiracy", "1", @client) == []
+    end
+  end
+
+  test "create/5" do
+    body = %{
+      "content" => ":+1:",
+    }
+    use_cassette "pulls/comments/reactions#create" do
+      {status_code, _} = create("soudqwiggle", "elixir-conspiracy", "1", body, @client)
+      assert status_code == 201
+    end
+  end
+end

--- a/test/reactions_test.exs
+++ b/test/reactions_test.exs
@@ -1,0 +1,20 @@
+defmodule Tentacat.ReactionsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Reactions
+
+  doctest Tentacat.Releases
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start
+  end
+
+  test "delete/4" do
+    use_cassette "reactions#delete" do
+      {status_code, _} = delete(2317708, "soudqwiggle", "elixir-conspiracy", @client)
+      assert status_code == 204
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request supports the following actions on reactions
  - List reactions for a commit comment
  - Create reaction for a commit comment
  - List reactions for an issue
  - Create reaction for an issue
  - List reactions for an issue comment
  - Create reaction for an issue comment
  - List reactions for a pull request review comment
  - Create reaction for a pull request review comment
  - Delete a reaction

More info: https://developer.github.com/v3/reactions/
