### PR TITLE
more github installations api coverage

### DIFF
--- a/lib/tentacat/app.ex
+++ b/lib/tentacat/app.ex
@@ -16,4 +16,18 @@ defmodule Tentacat.App do
     get "app", client
   end
 
+  @doc """
+  Get info for a single app
+
+  ## Example
+
+      Tentacat.App.find "tentacatty"
+
+  More info at: https://developer.github.com/v3/apps/#get-a-single-github-app
+  """
+  @spec find(string, Client.t) :: Tentacat.response
+  def find(slug, client \\ %Client{}) do
+    get "apps/#{slug}", client
+  end
+
 end

--- a/lib/tentacat/app/installations.ex
+++ b/lib/tentacat/app/installations.ex
@@ -17,6 +17,20 @@ defmodule Tentacat.App.Installations do
   end
 
   @doc """
+  List installations accessible with the authenticated app user
+
+  ## Example
+
+      Tentacat.App.Installations.list_for_user client
+
+  More info at: https://developer.github.com/v3/apps/#list-installations-for-user
+  """
+  @spec list_for_user(Client.t) :: Tentacat.response
+  def list_for_user(client) do
+    get "user/installations", client
+  end
+
+  @doc """
   Get a specific installation
 
   ## Example
@@ -42,6 +56,34 @@ defmodule Tentacat.App.Installations do
   @spec token(integer, Client.t) :: Tentacat.response
   def token(installation_id, client) do
     post "app/installations/#{installation_id}/access_tokens", client
+  end
+
+  @doc """
+  List repositories for the authenticated installation
+
+  ## Example
+
+      Tentacat.App.Installations.list_repositories client
+
+  More info at: https://developer.github.com/v3/apps/installations/#list-repositories
+  """
+  @spec list_repositories(Client.t) :: Tentacat.response
+  def list_repositories(client) do
+    get "installation/repositories", client
+  end
+
+  @doc """
+  List repositories in an installation that are accessible with to the authenticated app user
+
+  ## Example
+
+      Tentacat.App.Installations.list_repositories_for_user 154, client
+
+  More info at: https://developer.github.com/v3/apps/#list-installations-for-user
+  """
+  @spec list_repositories_for_user(integer, Client.t) :: Tentacat.response
+  def list_repositories_for_user(installation_id, client) do
+    get "user/installations/#{installation_id}/repositories", client
   end
 
 end

--- a/test/app/installations_test.exs
+++ b/test/app/installations_test.exs
@@ -30,4 +30,14 @@ defmodule Tentacat.App.InstallationsTest do
       assert elem(token(66216, @client), 1)["token"] == "v1.b328f705dbba381a0f61697986a8faa09dacb097"
     end
   end
+
+  test "list_repositories/1" do
+    use_cassette "app/installations#list_repositories" do
+      token = elem(token(66216, @client), 1)["token"]
+      client = Tentacat.Client.new %{access_token: token}
+      %{"repositories" => repositories} = list_repositories client
+      assert length(repositories) == 2
+    end
+  end
+
 end

--- a/test/app_test.exs
+++ b/test/app_test.exs
@@ -18,4 +18,11 @@ defmodule Tentacat.AppTest do
       assert me(@client)["name"] == "tentacatty"
     end
   end
+
+  test "find/1" do
+    use_cassette "app#find" do
+      %{"name" => name} = find("tentacatty")
+      assert name == "tentacatty"
+    end
+  end
 end

--- a/test/fixture/vcr_cassettes/app#find.json
+++ b/test/fixture/vcr_cassettes/app#find.json
@@ -1,0 +1,43 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/apps/tentacatty"
+    },
+    "response": {
+      "body": "{\"id\":6615,\"owner\":{\"login\":\"outofambit\",\"id\":964912,\"avatar_url\":\"https://avatars3.githubusercontent.com/u/964912?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/outofambit\",\"html_url\":\"https://github.com/outofambit\",\"followers_url\":\"https://api.github.com/users/outofambit/followers\",\"following_url\":\"https://api.github.com/users/outofambit/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/outofambit/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/outofambit/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/outofambit/subscriptions\",\"organizations_url\":\"https://api.github.com/users/outofambit/orgs\",\"repos_url\":\"https://api.github.com/users/outofambit/repos\",\"events_url\":\"https://api.github.com/users/outofambit/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/outofambit/received_events\",\"type\":\"User\",\"site_admin\":false},\"name\":\"tentacatty\",\"description\":\"for testing\",\"external_url\":\"https://github.com/outofambit/tentacat\",\"html_url\":\"https://github.com/apps/tentacatty\",\"created_at\":\"2017-11-09T21:10:27Z\",\"updated_at\":\"2017-11-20T18:34:51Z\"}",
+      "headers": {
+        "Date": "Mon, 20 Nov 2017 18:36:05 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1139",
+        "Server": "GitHub.com",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "60",
+        "X-RateLimit-Remaining": "51",
+        "X-RateLimit-Reset": "1511206210",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"ae90aa6d57a8d6bdf12e90d90c3daa4d\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.019412",
+        "X-GitHub-Request-Id": "DE76:2B93:6FB05DA:8196AA3:5A132094"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/app/installations#list_repositories.json
+++ b/test/fixture/vcr_cassettes/app/installations#list_repositories.json
@@ -1,0 +1,83 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat",
+        "Authorization": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/app/installations/66216/access_tokens"
+    },
+    "response": {
+      "body": "{\"token\":\"v1.d3ae3344ada13f5ec947eac962fe1e0f906c2154\",\"expires_at\":\"2017-11-20T23:07:30Z\"}",
+      "headers": {
+        "Date": "Mon, 20 Nov 2017 22:07:30 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "91",
+        "Server": "GitHub.com",
+        "Status": "201 Created",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"080ec01aeb51b3f5b81b7faf06817b7d\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.029370",
+        "X-GitHub-Request-Id": "EAE3:2B91:420D091:4CABBBA:5A135222"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "Accept": "application/vnd.github.machine-man-preview+json",
+        "User-agent": "tentacat",
+        "Authorization": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/installation/repositories"
+    },
+    "response": {
+      "body": "{\"total_count\":2,\"repository_selection\":\"selected\",\"repositories\":[{\"id\":103584391,\"name\":\"musical-spork\",\"full_name\":\"outofambit/musical-spork\",\"owner\":{\"login\":\"outofambit\",\"id\":964912,\"avatar_url\":\"https://avatars3.githubusercontent.com/u/964912?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/outofambit\",\"html_url\":\"https://github.com/outofambit\",\"followers_url\":\"https://api.github.com/users/outofambit/followers\",\"following_url\":\"https://api.github.com/users/outofambit/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/outofambit/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/outofambit/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/outofambit/subscriptions\",\"organizations_url\":\"https://api.github.com/users/outofambit/orgs\",\"repos_url\":\"https://api.github.com/users/outofambit/repos\",\"events_url\":\"https://api.github.com/users/outofambit/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/outofambit/received_events\",\"type\":\"User\",\"site_admin\":false},\"private\":true,\"html_url\":\"https://github.com/outofambit/musical-spork\",\"description\":null,\"fork\":false,\"url\":\"https://api.github.com/repos/outofambit/musical-spork\",\"forks_url\":\"https://api.github.com/repos/outofambit/musical-spork/forks\",\"keys_url\":\"https://api.github.com/repos/outofambit/musical-spork/keys{/key_id}\",\"collaborators_url\":\"https://api.github.com/repos/outofambit/musical-spork/collaborators{/collaborator}\",\"teams_url\":\"https://api.github.com/repos/outofambit/musical-spork/teams\",\"hooks_url\":\"https://api.github.com/repos/outofambit/musical-spork/hooks\",\"issue_events_url\":\"https://api.github.com/repos/outofambit/musical-spork/issues/events{/number}\",\"events_url\":\"https://api.github.com/repos/outofambit/musical-spork/events\",\"assignees_url\":\"https://api.github.com/repos/outofambit/musical-spork/assignees{/user}\",\"branches_url\":\"https://api.github.com/repos/outofambit/musical-spork/branches{/branch}\",\"tags_url\":\"https://api.github.com/repos/outofambit/musical-spork/tags\",\"blobs_url\":\"https://api.github.com/repos/outofambit/musical-spork/git/blobs{/sha}\",\"git_tags_url\":\"https://api.github.com/repos/outofambit/musical-spork/git/tags{/sha}\",\"git_refs_url\":\"https://api.github.com/repos/outofambit/musical-spork/git/refs{/sha}\",\"trees_url\":\"https://api.github.com/repos/outofambit/musical-spork/git/trees{/sha}\",\"statuses_url\":\"https://api.github.com/repos/outofambit/musical-spork/statuses/{sha}\",\"languages_url\":\"https://api.github.com/repos/outofambit/musical-spork/languages\",\"stargazers_url\":\"https://api.github.com/repos/outofambit/musical-spork/stargazers\",\"contributors_url\":\"https://api.github.com/repos/outofambit/musical-spork/contributors\",\"subscribers_url\":\"https://api.github.com/repos/outofambit/musical-spork/subscribers\",\"subscription_url\":\"https://api.github.com/repos/outofambit/musical-spork/subscription\",\"commits_url\":\"https://api.github.com/repos/outofambit/musical-spork/commits{/sha}\",\"git_commits_url\":\"https://api.github.com/repos/outofambit/musical-spork/git/commits{/sha}\",\"comments_url\":\"https://api.github.com/repos/outofambit/musical-spork/comments{/number}\",\"issue_comment_url\":\"https://api.github.com/repos/outofambit/musical-spork/issues/comments{/number}\",\"contents_url\":\"https://api.github.com/repos/outofambit/musical-spork/contents/{+path}\",\"compare_url\":\"https://api.github.com/repos/outofambit/musical-spork/compare/{base}...{head}\",\"merges_url\":\"https://api.github.com/repos/outofambit/musical-spork/merges\",\"archive_url\":\"https://api.github.com/repos/outofambit/musical-spork/{archive_format}{/ref}\",\"downloads_url\":\"https://api.github.com/repos/outofambit/musical-spork/downloads\",\"issues_url\":\"https://api.github.com/repos/outofambit/musical-spork/issues{/number}\",\"pulls_url\":\"https://api.github.com/repos/outofambit/musical-spork/pulls{/number}\",\"milestones_url\":\"https://api.github.com/repos/outofambit/musical-spork/milestones{/number}\",\"notifications_url\":\"https://api.github.com/repos/outofambit/musical-spork/notifications{?since,all,participating}\",\"labels_url\":\"https://api.github.com/repos/outofambit/musical-spork/labels{/name}\",\"releases_url\":\"https://api.github.com/repos/outofambit/musical-spork/releases{/id}\",\"deployments_url\":\"https://api.github.com/repos/outofambit/musical-spork/deployments\",\"created_at\":\"2017-09-14T21:40:13Z\",\"updated_at\":\"2017-09-19T16:17:58Z\",\"pushed_at\":\"2017-11-14T20:05:38Z\",\"git_url\":\"git://github.com/outofambit/musical-spork.git\",\"ssh_url\":\"git@github.com:outofambit/musical-spork.git\",\"clone_url\":\"https://github.com/outofambit/musical-spork.git\",\"svn_url\":\"https://github.com/outofambit/musical-spork\",\"homepage\":null,\"size\":12,\"stargazers_count\":0,\"watchers_count\":0,\"language\":null,\"has_issues\":false,\"has_projects\":false,\"has_downloads\":true,\"has_wiki\":false,\"has_pages\":false,\"forks_count\":0,\"mirror_url\":null,\"archived\":false,\"open_issues_count\":0,\"forks\":0,\"open_issues\":0,\"watchers\":0,\"default_branch\":\"master\",\"permissions\":{\"admin\":false,\"push\":false,\"pull\":false}},{\"id\":109875745,\"name\":\"tentacat\",\"full_name\":\"outofambit/tentacat\",\"owner\":{\"login\":\"outofambit\",\"id\":964912,\"avatar_url\":\"https://avatars3.githubusercontent.com/u/964912?v=4\",\"gravatar_id\":\"\",\"url\":\"https://api.github.com/users/outofambit\",\"html_url\":\"https://github.com/outofambit\",\"followers_url\":\"https://api.github.com/users/outofambit/followers\",\"following_url\":\"https://api.github.com/users/outofambit/following{/other_user}\",\"gists_url\":\"https://api.github.com/users/outofambit/gists{/gist_id}\",\"starred_url\":\"https://api.github.com/users/outofambit/starred{/owner}{/repo}\",\"subscriptions_url\":\"https://api.github.com/users/outofambit/subscriptions\",\"organizations_url\":\"https://api.github.com/users/outofambit/orgs\",\"repos_url\":\"https://api.github.com/users/outofambit/repos\",\"events_url\":\"https://api.github.com/users/outofambit/events{/privacy}\",\"received_events_url\":\"https://api.github.com/users/outofambit/received_events\",\"type\":\"User\",\"site_admin\":false},\"private\":false,\"html_url\":\"https://github.com/outofambit/tentacat\",\"description\":\"Simple Elixir wrapper for the GitHub API\",\"fork\":true,\"url\":\"https://api.github.com/repos/outofambit/tentacat\",\"forks_url\":\"https://api.github.com/repos/outofambit/tentacat/forks\",\"keys_url\":\"https://api.github.com/repos/outofambit/tentacat/keys{/key_id}\",\"collaborators_url\":\"https://api.github.com/repos/outofambit/tentacat/collaborators{/collaborator}\",\"teams_url\":\"https://api.github.com/repos/outofambit/tentacat/teams\",\"hooks_url\":\"https://api.github.com/repos/outofambit/tentacat/hooks\",\"issue_events_url\":\"https://api.github.com/repos/outofambit/tentacat/issues/events{/number}\",\"events_url\":\"https://api.github.com/repos/outofambit/tentacat/events\",\"assignees_url\":\"https://api.github.com/repos/outofambit/tentacat/assignees{/user}\",\"branches_url\":\"https://api.github.com/repos/outofambit/tentacat/branches{/branch}\",\"tags_url\":\"https://api.github.com/repos/outofambit/tentacat/tags\",\"blobs_url\":\"https://api.github.com/repos/outofambit/tentacat/git/blobs{/sha}\",\"git_tags_url\":\"https://api.github.com/repos/outofambit/tentacat/git/tags{/sha}\",\"git_refs_url\":\"https://api.github.com/repos/outofambit/tentacat/git/refs{/sha}\",\"trees_url\":\"https://api.github.com/repos/outofambit/tentacat/git/trees{/sha}\",\"statuses_url\":\"https://api.github.com/repos/outofambit/tentacat/statuses/{sha}\",\"languages_url\":\"https://api.github.com/repos/outofambit/tentacat/languages\",\"stargazers_url\":\"https://api.github.com/repos/outofambit/tentacat/stargazers\",\"contributors_url\":\"https://api.github.com/repos/outofambit/tentacat/contributors\",\"subscribers_url\":\"https://api.github.com/repos/outofambit/tentacat/subscribers\",\"subscription_url\":\"https://api.github.com/repos/outofambit/tentacat/subscription\",\"commits_url\":\"https://api.github.com/repos/outofambit/tentacat/commits{/sha}\",\"git_commits_url\":\"https://api.github.com/repos/outofambit/tentacat/git/commits{/sha}\",\"comments_url\":\"https://api.github.com/repos/outofambit/tentacat/comments{/number}\",\"issue_comment_url\":\"https://api.github.com/repos/outofambit/tentacat/issues/comments{/number}\",\"contents_url\":\"https://api.github.com/repos/outofambit/tentacat/contents/{+path}\",\"compare_url\":\"https://api.github.com/repos/outofambit/tentacat/compare/{base}...{head}\",\"merges_url\":\"https://api.github.com/repos/outofambit/tentacat/merges\",\"archive_url\":\"https://api.github.com/repos/outofambit/tentacat/{archive_format}{/ref}\",\"downloads_url\":\"https://api.github.com/repos/outofambit/tentacat/downloads\",\"issues_url\":\"https://api.github.com/repos/outofambit/tentacat/issues{/number}\",\"pulls_url\":\"https://api.github.com/repos/outofambit/tentacat/pulls{/number}\",\"milestones_url\":\"https://api.github.com/repos/outofambit/tentacat/milestones{/number}\",\"notifications_url\":\"https://api.github.com/repos/outofambit/tentacat/notifications{?since,all,participating}\",\"labels_url\":\"https://api.github.com/repos/outofambit/tentacat/labels{/name}\",\"releases_url\":\"https://api.github.com/repos/outofambit/tentacat/releases{/id}\",\"deployments_url\":\"https://api.github.com/repos/outofambit/tentacat/deployments\",\"created_at\":\"2017-11-07T18:39:49Z\",\"updated_at\":\"2017-11-07T18:39:51Z\",\"pushed_at\":\"2017-11-15T22:33:16Z\",\"git_url\":\"git://github.com/outofambit/tentacat.git\",\"ssh_url\":\"git@github.com:outofambit/tentacat.git\",\"clone_url\":\"https://github.com/outofambit/tentacat.git\",\"svn_url\":\"https://github.com/outofambit/tentacat\",\"homepage\":null,\"size\":433,\"stargazers_count\":0,\"watchers_count\":0,\"language\":\"Elixir\",\"has_issues\":false,\"has_projects\":true,\"has_downloads\":true,\"has_wiki\":true,\"has_pages\":false,\"forks_count\":0,\"mirror_url\":null,\"archived\":false,\"open_issues_count\":0,\"forks\":0,\"open_issues\":0,\"watchers\":0,\"default_branch\":\"master\",\"permissions\":{\"admin\":false,\"push\":false,\"pull\":false}}]}",
+      "headers": {
+        "Date": "Mon, 20 Nov 2017 22:07:31 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "9841",
+        "Server": "GitHub.com",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4997",
+        "X-RateLimit-Reset": "1511219052",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"40c59d62e712e8fa0b72d6d38f63cba8\"",
+        "X-GitHub-Media-Type": "github.machine-man-preview; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Runtime-rack": "0.043338",
+        "X-GitHub-Request-Id": "EAE3:2B91:420D0AF:4CABBD0:5A135222"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]


### PR DESCRIPTION
Expands coverage of GitHub App and Installation API.

There are a two untested methods because they require an OAuth handshake by a user and an app (via the GitHub UI).

I was a little unsure of some naming in here so if anything sticks out and you have a suggestion, please let me know!