### PR TITLE
Fix a few compilation warnings

### DIFF
--- a/lib/tentacat/app.ex
+++ b/lib/tentacat/app.ex
@@ -25,7 +25,7 @@ defmodule Tentacat.App do
 
   More info at: https://developer.github.com/v3/apps/#get-a-single-github-app
   """
-  @spec find(string, Client.t) :: Tentacat.response
+  @spec find(binary, Client.t) :: Tentacat.response
   def find(slug, client \\ %Client{}) do
     get "apps/#{slug}", client
   end

--- a/test/repositories_test.exs
+++ b/test/repositories_test.exs
@@ -62,9 +62,9 @@ defmodule Tentacat.RepositoriesTest do
     end
   end
 
-  test "list_public/1" do
+  test "list_public/0" do
     use_cassette "repositories#list_public", match_requests_on: [:query] do
-      assert list_public == []
+      assert list_public() == []
     end
   end
 


### PR DESCRIPTION
```
warning: string() type use is discouraged. For character lists, use charlist()
type, for strings, String.t()
  lib/tentacat/app.ex:28

warning: variable "list_public" does not exist and is being expanded to
"list_public()", please use parentheses to remove the ambiguity or change the
variable name
  test/repositories_test.exs:67
```