### PR TITLE
Upgrade exjsx and exvcr

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,12 +23,12 @@ defmodule Tentacat.Mixfile do
 
   defp deps do
    [ {:httpoison, "~> 0.8"},
-     {:exjsx, "~> 3.2"},
+     {:exjsx, "~> 4.0"},
      {:earmark, "~> 0.2.1", only: :dev},
      {:ex_doc, "~> 0.11.4", only: :dev},
      {:inch_ex, "~> 0.5", only: :dev},
      {:excoveralls, "~> 0.5", only: :test},
-     {:exvcr, "~> 0.8", only: :test} ,
+     {:exvcr, "~> 0.9.1", only: :test},
      {:meck, "~> 0.8.9", only: :test} ]
   end
 


### PR DESCRIPTION
No breaking changes for exvcr between 0.8 and 0.9.

I didn't found any changelog on the exjsx repository, but this looks like a breaking change: https://github.com/talentdeficit/exjsx/commit/b52ec15af0d84f9ad204fd2309230cb1651269cd