### PR TITLE
Update auth typedef to include JWT option

### DIFF
--- a/lib/tentacat/client.ex
+++ b/lib/tentacat/client.ex
@@ -1,7 +1,7 @@
 defmodule Tentacat.Client do
   defstruct auth: nil, endpoint: "https://api.github.com/"
 
-  @type auth :: %{user: binary, password: binary} | %{access_token: binary}
+  @type auth :: %{user: binary, password: binary} | %{access_token: binary} | %{jwt: binary}
   @type t :: %__MODULE__{auth: auth, endpoint: binary}
 
   @spec new() :: t


### PR DESCRIPTION
In #129, support was added for initializing a client with a JWT. However, the Dialyzer typedef wasn’t updated, which causes the following error:

```
The call 'Elixir.Tentacat.Client':new(#{'jwt':=<<_:16,_:_*8>> | [<<_:16,_:_*8>>]}) breaks the contract (auth()) -> t()
```

This commit fixes that issue.