### PR TITLE
Switch to using the remove memberships api

### DIFF
--- a/lib/tentacat/organizations/members.ex
+++ b/lib/tentacat/organizations/members.ex
@@ -41,11 +41,11 @@ defmodule Tentacat.Organizations.Members do
 
       Tentacat.Organizations.Members.remove "github", "mojombo", client
 
-  More info at: http://developer.github.com/v3/orgs/members/#remove-a-member
+  More info at: http://developer.github.com/v3/orgs/members/#remove-organization-membership
   """
   @spec remove(binary, binary, Client.t) :: Tentacat.response
   def remove(organization, user, client) do
-    delete "orgs/#{organization}/members/#{user}", client
+    delete "orgs/#{organization}/memberships/#{user}", client
   end
 
   @doc """

--- a/test/fixture/vcr_cassettes/members#remove.json
+++ b/test/fixture/vcr_cassettes/members#remove.json
@@ -9,7 +9,7 @@
       "method": "delete",
       "options": [],
       "request_body": "",
-      "url": "https://api.github.com/orgs/tentatest/members/duksis"
+      "url": "https://api.github.com/orgs/tentatest/memberships/duksis"
     },
     "response": {
       "body": "",


### PR DESCRIPTION
This seems to do the same thing as the members api but it also removes invitations.

This seems like a fine change to me but if you'd prefer, I can change this to a new remove function (remove_memberships maybe?) if that sounds better.