### PR TITLE
Implement configurable deserialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,25 @@ iex> Tentacat.Users.me(client)
 ```
 
 ## Misc
+
 Having that Github Reviews API is still in a pre-release state
 you need to set an additional header in your config.
 
 ```elixir
-config :tentacat, :extra_headers, [{"Accept", "application/vnd.github.black-cat-preview+json"}])
+config :tentacat, :extra_headers, [{"Accept", "application/vnd.github.black-cat-preview+json"}]
 ```
+
+### Deserialization Options
+
+You can pass deserialization options to the library used to decode JSON
+using:
+
+```elixir
+# To have Atom keys
+config :tentacat, :deserialization_options, [labels: :atoms]
+```
+
+See: https://github.com/talentdeficit/exjsx#decodejson-opts for available options.
 
 ## Contributing
 

--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -9,7 +9,7 @@ defmodule Tentacat do
 
   @spec process_response_body(binary) :: term
   def process_response_body(""), do: nil
-  def process_response_body(body), do: JSX.decode!(body)
+  def process_response_body(body), do: JSX.decode!(body, deserialization_options())
 
   @spec process_response(HTTPoison.Response.t()) :: response
   def process_response(%HTTPoison.Response{status_code: status_code, body: body} = resp),
@@ -76,6 +76,10 @@ defmodule Tentacat do
 
   defp extra_headers do
     Application.get_env(:tentacat, :extra_headers, [])
+  end
+
+  defp deserialization_options do
+    Application.get_env(:tentacat, :deserialization_options, [labels: :binary])
   end
 
   defp pagination(options) do

--- a/test/tentacat_test.exs
+++ b/test/tentacat_test.exs
@@ -12,6 +12,12 @@ defmodule TentacatTest do
     end)
   end
 
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:tentacat, :deserialization_options)
+    end)
+  end
+
   test "authorization_header using user and password" do
     assert authorization_header(%{user: "user", password: "password"}, []) == [
              {"Authorization", "Basic dXNlcjpwYXNzd29yZA=="}
@@ -50,7 +56,16 @@ defmodule TentacatTest do
   end
 
   test "process_response_body with content" do
-    :meck.expect(JSX, :decode!, 1, :decoded_json)
+    :meck.expect(JSX, :decode!, 2, :decoded_json)
+
+    assert process_response_body("json") == :decoded_json
+  end
+
+  test "process_response_body with serialization options" do
+    Application.put_env :tentacat, :deserialization_options, [keys: :atoms]
+
+    :meck.expect(JSX, :decode!, fn _, [keys: :atoms] -> :decoded_json end)
+
     assert process_response_body("json") == :decoded_json
   end
 


### PR DESCRIPTION
Closes: #102 

This PR implements a new config option where the user can provide options to the function of the library handling JSON deserialization.

It preserves the current default behaviour where keys are binaries but a user can easily swap the default with one of the available options of JSX (https://github.com/talentdeficit/exjsx#exports).