### PR TITLE
Updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ First, add Tentacat to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:tentacat, "~> 0.9"}]
+  [{:tentacat, "~> 1.0"}]
 end
 ```
 
 Ensure that `tentacat` is added as an application in your `mix.exs`:
+
+_(note: this is only necessary for Elixir < 1.3)_
 
 ```elixir
 def application do


### PR DESCRIPTION
This updates the version in the example and makes note that tentacat only needs to be added to mix.exs applications for Elixir versions before 1.3