### PR TITLE
Add /fixture to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_build
 /ebin
 /deps
+/fixture
 /.elixir_ls
 erl_crash.dump
 docs


### PR DESCRIPTION
# Description

Right now, every time a test fails, `exvcr` generates the folder `fixture` with the errors, which shouldn't be included in the repo, so `fixture` is added to `.gitignore`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
Make sure a test will fail
Run `mix test`
Git won't detect the generated files under `/fixture`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings