### PR TITLE
Force a check of passed creds

### DIFF
--- a/lib/tentacat/client.ex
+++ b/lib/tentacat/client.ex
@@ -4,14 +4,35 @@ defmodule Tentacat.Client do
   @type auth :: %{user: binary, password: binary} | %{access_token: binary} | %{jwt: binary}
   @type t :: %__MODULE__{auth: auth, endpoint: binary}
 
-  @spec new() :: t
+  @spec new():: Tentacat.Client.t()
   def new(), do: %__MODULE__{}
 
-  @spec new(auth) :: t
-  def new(auth), do: %__MODULE__{auth: auth}
+  @spec new(map()) :: Tentacat.Client.t()
+  def new(auth = %{user: _, password: _}), do: %__MODULE__{auth: auth}
+
+  @spec new(map()) :: Tentacat.Client.t()
+  def new(auth = %{access_token: _}), do: %__MODULE__{auth: auth}
+
+  @spec new(map()) :: Tentacat.Client.t()
+  def new(auth = %{jwt: _}), do: %__MODULE__{auth: auth}
+
+  @spec new(map(), binary) :: t
+  def new(auth = %{access_token: _}, endpoint) do
+    pnew(auth, endpoint)
+  end
+
+  @spec new(map(), binary) :: t
+  def new(auth = %{user: _, password: _}, endpoint) do
+    pnew(auth, endpoint)
+  end
+
+  @spec new(map(), binary) :: t
+  def new(auth = %{jwt: _}, endpoint) do
+   pnew(auth, endpoint)
+  end
 
   @spec new(auth, binary) :: t
-  def new(auth, endpoint) do
+  defp pnew(auth, endpoint) do
     endpoint =
       if String.ends_with?(endpoint, "/") do
         endpoint


### PR DESCRIPTION
Every time I come back to this library I make the same mistake and it costs my hours to debug. 

I instantiate the client like so : 

`c =  Tentacat.Client.new("my secret github token" )`

Rather than :  

`c =  Tentacat.Client.new( %{access_token: "my secret github token" }` 

This PR is an attempt to prevent others from making a similar mistake.