### PR TITLE
fix auto pagination bug

### DIFF
--- a/lib/tentacat/client.ex
+++ b/lib/tentacat/client.ex
@@ -2,7 +2,7 @@ defmodule Tentacat.Client do
   defstruct auth: nil, endpoint: "https://api.github.com/"
 
   @type auth :: %{user: binary, password: binary} | %{access_token: binary} | %{jwt: binary}
-  @type t :: %__MODULE__{auth: auth, endpoint: binary}
+  @type t :: %__MODULE__{auth: auth | nil, endpoint: binary}
 
   @spec new() :: t
   def new(), do: %__MODULE__{}

--- a/lib/tentacat/repositories.ex
+++ b/lib/tentacat/repositories.ex
@@ -32,7 +32,7 @@ defmodule Tentacat.Repositories do
 
   More info at: https://developer.github.com/v3/repos/#list-user-repositories
   """
-  @spec list_users(Client.t(), binary, Keyword.t()) :: Tentacat.response()
+  @spec list_users(Client.t(), binary, Keyword.t(), Keyword.t()) :: Tentacat.response()
   def list_users(client \\ %Client{}, owner, params \\ [], options \\ []) do
     get("users/#{owner}/repos", client, params, options)
   end

--- a/test/repositories_test.exs
+++ b/test/repositories_test.exs
@@ -26,7 +26,7 @@ defmodule Tentacat.RepositoriesTest do
 
   test "list_users/2 with auto-pagination" do
     use_cassette "repositories#list_user_auto_pagination", match_requests_on: [:query] do
-      all_repos = list_users(@client, "jeffweiss", [], pagination: :auto)
+      {_, all_repos, _} = list_users(@client, "jeffweiss", [], pagination: :auto)
       assert Enum.count(all_repos) > 130
     end
   end

--- a/test/tentacat_test.exs
+++ b/test/tentacat_test.exs
@@ -62,7 +62,7 @@ defmodule TentacatTest do
   end
 
   test "process_response_body with serialization options" do
-    Application.put_env :tentacat, :deserialization_options, [keys: :atoms]
+    Application.put_env(:tentacat, :deserialization_options, keys: :atoms)
 
     :meck.expect(JSX, :decode!, fn _, [keys: :atoms] -> :decoded_json end)
 


### PR DESCRIPTION
closes #144 

In some cases, (the default) `:auto` pagination would return the response body instead of the specified response tuple. I've refactored the `get/4` to keep align these cases and added a number of typings for clarity.

There are still some type issues in `tentacat.ex`, but I'd rather me (or someone else) tackle more of them in a future pull request.

Also fixed a small type mistake in `Client.t()`.