### PR TITLE
Update HTTPoison, ExVCR

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,8 @@
+use Mix.Config
+
+config :exvcr, [
+  vcr_cassette_library_dir: "test/fixture/vcr_cassettes",
+  filter_sensitive_data: [
+    [pattern: "token [^\"]+", placeholder: "token yourtokencomeshere"]
+  ]
+]

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Tentacat.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 1.0.0"},
+      {:httpoison, "~> 1.3.0"},
       {:exjsx, "~> 4.0"},
       {:earmark, "~> 0.2.1", only: :dev},
       {:ex_doc, "~> 0.11.4", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -25,13 +25,13 @@ defmodule Tentacat.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.8"},
+      {:httpoison, "~> 1.0.0"},
       {:exjsx, "~> 4.0"},
       {:earmark, "~> 0.2.1", only: :dev},
       {:ex_doc, "~> 0.11.4", only: :dev},
       {:inch_ex, "~> 0.5", only: :dev},
       {:excoveralls, "~> 0.5", only: :test},
-      {:exvcr, "~> 0.9.1", only: :test},
+      {:exvcr, "~> 0.10.3", only: :test},
       {:meck, "~> 0.8.9", only: :test}
     ]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,2 @@
 ExUnit.configure(exclude: [skip: true])
 ExUnit.start()
-ExVCR.Config.cassette_library_dir("test/fixture/vcr_cassettes")
-ExVCR.Config.filter_sensitive_data("token [^\"]+", "token yourtokencomeshere")


### PR DESCRIPTION
* Updates HTTPoison to 1.3.0 (since 1.4.0+ requires [some work to be done on HTTPoison](https://github.com/edgurgel/tentacat/issues/152) itself)
* Updates ExVCR to 0.10.3 - required moving of VCR configuration to the Mix config file (solves the issue [encountered here](https://github.com/edgurgel/tentacat/pull/155#issuecomment-427704253))