### PR TITLE
switch client and username parameter in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Getting info from a user using a client
 ```elixir
 iex> client = Tentacat.Client.new
 %Tentacat.Client{auth: nil, endpoint: "https://api.github.com/"}
-iex> Tentacat.Users.find "edgurgel", client
+iex> Tentacat.Users.find client, "edgurgel"
 {200,
  %{"avatar_url" => "https://avatars0.githubusercontent.com/u/30873?v=4",
    "bio" => "INSUFFICIENT DATA FOR MEANINGFUL ANSWER",

--- a/lib/tentacat/users.ex
+++ b/lib/tentacat/users.ex
@@ -7,8 +7,8 @@ defmodule Tentacat.Users do
 
   ## Example
 
-      Tentacat.Users.find "edgurgel", client
-      Tentacat.Users.find "iurifq", client
+      Tentacat.Users.find client, "edgurgel"
+      Tentacat.Users.find client, "iurifq"
 
   More info at: http://developer.github.com/v3/users/#get-a-single-user
   """


### PR DESCRIPTION
fix https://github.com/edgurgel/tentacat/issues/165

- update readme example for `Tentacat.Users.find`

The function has to be written in this order:
Tentacat.Users.find Tentacat.Client.new, "edgurgel"