### PR TITLE
update path to fetch installation token

### DIFF
--- a/lib/tentacat/app/installations.ex
+++ b/lib/tentacat/app/installations.ex
@@ -55,7 +55,7 @@ defmodule Tentacat.App.Installations do
   """
   @spec token(Client.t(), integer) :: Tentacat.response()
   def token(client, installation_id) do
-    post("app/installations/#{installation_id}/access_tokens", client)
+    post("installations/#{installation_id}/access_tokens", client)
   end
 
   @doc """

--- a/test/fixture/vcr_cassettes/app/installations#list_repositories.json
+++ b/test/fixture/vcr_cassettes/app/installations#list_repositories.json
@@ -10,7 +10,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://api.github.com/app/installations/66216/access_tokens"
+      "url": "https://api.github.com/installations/66216/access_tokens"
     },
     "response": {
       "body": "{\"token\":\"v1.d3ae3344ada13f5ec947eac962fe1e0f906c2154\",\"expires_at\":\"2017-11-20T23:07:30Z\"}",

--- a/test/fixture/vcr_cassettes/app/installations#token.json
+++ b/test/fixture/vcr_cassettes/app/installations#token.json
@@ -10,7 +10,7 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://api.github.com/app/installations/66216/access_tokens"
+      "url": "https://api.github.com/installations/66216/access_tokens"
     },
     "response": {
       "body": "{\"token\":\"v1.b328f705dbba381a0f61697986a8faa09dacb097\",\"expires_at\":\"2017-11-09T23:05:38Z\"}",


### PR DESCRIPTION
Since https://developer.github.com/v3/apps/ are still in beta (life sucks!), they have changed api to fetch tokens once again.

If we do `Tentacat.App.Installations.list_mine(t)`, response is something like this:

```js
{200,
 [
   %{
     "access_tokens_url" => "https://api.github.com/installations/929200/access_tokens",
     "account" => %{
       "avatar_url" => "https://avatars0.githubusercontent.com/u/1137275?v=4",
       "snip" => "<all-other-urls>"
     },
     "app_id" => 16094,
     "created_at" => "2019-04-08T01:55:18.000Z",
     "events" => ["commit_comment", "create", "delete", "deployment",
      "deployment_status", "member", "membership", "pull_request", "push"],
     "id" => 929200,
     "permissions" => %{
       "contents" => "read",
       "deployments" => "write",
       "members" => "read",
       "metadata" => "read",
       "organization_projects" => "read",
       "pull_requests" => "read"
     },
     "repositories_url" => "https://api.github.com/installation/repositories",
     "repository_selection" => "selected",
     "single_file_name" => nil,
     "target_id" => 2237275,
     "target_type" => "Organization",
     "updated_at" => "2019-04-08T01:55:18.000Z"
   }
 ],
 %HTTPoison.Response{
   body: [
     %{
       "snip" => "all-content"
     }
   ],
   headers: [
     {"Date", "Mon, 08 Apr 2019 02:25:59 GMT"},
     {"Content-Type", "application/json; charset=utf-8"},
     {"Content-Length", "9751"},
     {"Server", "GitHub.com"},
     {"Status", "200 OK"},
     {"Cache-Control", "public, max-age=60, s-maxage=60"},
     {"Vary", "Accept"},
     {"X-GitHub-Media-Type", "github.machine-man-preview; format=json"},
     {"X-GitHub-Request-Id", "FA9F:91AE:26D9C84:2EE1D8C:5CAAB12E"}
   ],
   request_url: "https://api.github.com/app/installations",
   status_code: 200
 }}
```

So, if we check `access_tokens_url` key, its value is `https://api.github.com/installations/929200/access_tokens`, ie path is not prepended with `/app`. This PR fixes that!