### PR TITLE
Add support for Repositories Deploy Keys API 

### DIFF
--- a/lib/tentacat/repositories/deploy_keys.ex
+++ b/lib/tentacat/repositories/deploy_keys.ex
@@ -19,4 +19,19 @@ defmodule Tentacat.Repositories.DeployKeys do
   def list(client, owner, repo) do
     get("repos/#{owner}/#{repo}/keys", client)
   end
+
+  @doc """
+  Get a deploy key for a repository by id.
+
+  ## Example
+
+      Tentacat.Repositories.DeployKeys.find(client, "elixir-lang", "elixir", "1234567")
+
+  More info at: https://developer.github.com/v3/repos/keys/#get-a-deploy-key
+  """
+  @spec find(Client.t(), binary, binary, binary | integer) :: Tentacat.response()
+  def find(client, owner, repo, key_id) do
+    get("repos/#{owner}/#{repo}/keys/#{key_id}", client)
+  end
+
 end

--- a/lib/tentacat/repositories/deploy_keys.ex
+++ b/lib/tentacat/repositories/deploy_keys.ex
@@ -34,4 +34,18 @@ defmodule Tentacat.Repositories.DeployKeys do
     get("repos/#{owner}/#{repo}/keys/#{key_id}", client)
   end
 
+  @doc """
+  Create a deploy key for a repository.
+
+  ## Example
+
+      Tentacat.Repositories.DeployKeys.create(client, "elixir-lang", "elixir", key_body)
+
+  The key_body should be a map corresponding to a json body accepted by the api.
+  More info at: https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key
+  """
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, body) do
+    post("repos/#{owner}/#{repo}/keys", client, body)
+  end
 end

--- a/lib/tentacat/repositories/deploy_keys.ex
+++ b/lib/tentacat/repositories/deploy_keys.ex
@@ -1,0 +1,22 @@
+defmodule Tentacat.Repositories.DeployKeys do
+  import Tentacat
+  alias Tentacat.Client
+
+  @moduledoc """
+  The Repository deploy keys API allows repository admins to manage the deploy keys for a repository.
+  """
+
+  @doc """
+  Get a list of deploy keys for a repository.
+
+  ## Example
+
+      Tentacat.Repositories.DeployKeys.list(client, "elixir-lang", "elixir")
+
+  More info at: https://developer.github.com/v3/repos/keys/#list-deploy-keys
+  """
+  @spec list(Client.t(), binary, binary) :: Tentacat.response()
+  def list(client, owner, repo) do
+    get("repos/#{owner}/#{repo}/keys", client)
+  end
+end

--- a/lib/tentacat/repositories/deploy_keys.ex
+++ b/lib/tentacat/repositories/deploy_keys.ex
@@ -48,4 +48,18 @@ defmodule Tentacat.Repositories.DeployKeys do
   def create(client, owner, repo, body) do
     post("repos/#{owner}/#{repo}/keys", client, body)
   end
+
+  @doc """
+  Remove a deploy key from a repository.
+
+  ## Example
+
+      Tentacat.Repositories.DeployKeys.remove(client, "elixir-lang", "elixir", "1234567")
+
+  More info at: https://developer.github.com/v3/repos/keys/#remove-a-deploy-key
+  """
+  @spec remove(Client.t(), binary, binary, binary | integer) :: Tentacat.response()
+  def remove(client, owner, repo, key_id) do
+    delete("repos/#{owner}/#{repo}/keys/#{key_id}", client)
+  end
 end

--- a/test/fixture/vcr_cassettes/repositories/deploy_keys#create.json
+++ b/test/fixture/vcr_cassettes/repositories/deploy_keys#create.json
@@ -1,0 +1,47 @@
+[
+  {
+    "request": {
+      "body": "{\"key\":\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCc72ESoMRGBQJBjnUUSNo1uoRnV7PI82KtqfSLjcmj3fUB0OvVx8haMhtb7hlxKb5J7J2vLNONyRgNryUkOFTwfHpCt0TZqCKMvp9AuYyAQH2E1kbIGPQ/6BTCktGXq200Ua2hM5NNZjuCgxgMNoyxMzoSb5qChCXatQLIzbODBhyMEPwUq3PqAieirCEPIjXRr2jEAR9+xL8UnHb2e3ZcjuqZPB+yiZZSzZA5IDs3zW7RBQB6ZLoIInUWRxR41YE/2gNeUe4FwhXfxXane/4zkiNqqClE2rDo25MocVpqzP8niVuwQYPYsxEGOo/RIaQa55wvD/LMIwEaOVdbnRl7\",\"read_only\":true,\"title\":\"test_key\"}",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/milica-nerlovic/tentacat/keys"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"id\":34371109,\"key\":\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCc72ESoMRGBQJBjnUUSNo1uoRnV7PI82KtqfSLjcmj3fUB0OvVx8haMhtb7hlxKb5J7J2vLNONyRgNryUkOFTwfHpCt0TZqCKMvp9AuYyAQH2E1kbIGPQ/6BTCktGXq200Ua2hM5NNZjuCgxgMNoyxMzoSb5qChCXatQLIzbODBhyMEPwUq3PqAieirCEPIjXRr2jEAR9+xL8UnHb2e3ZcjuqZPB+yiZZSzZA5IDs3zW7RBQB6ZLoIInUWRxR41YE/2gNeUe4FwhXfxXane/4zkiNqqClE2rDo25MocVpqzP8niVuwQYPYsxEGOo/RIaQa55wvD/LMIwEaOVdbnRl7\",\"url\":\"https://api.github.com/repos/milica-nerlovic/tentacat/keys/34371109\",\"title\":\"test_key\",\"verified\":true,\"created_at\":\"2019-04-08T18:19:01Z\",\"read_only\":true}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Mon, 08 Apr 2019 18:19:01 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "568",
+        "Status": "201 Created",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4999",
+        "X-RateLimit-Reset": "1554751141",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"05a0ee6a2d40f0a37db12dd8db889afd\"",
+        "X-OAuth-Scopes": "admin:public_key, repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "Location": "https://api.github.com/repos/milica-nerlovic/tentacat/keys/34371109",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Frame-Options": "deny",
+        "X-Content-Type-Options": "nosniff",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'",
+        "X-GitHub-Request-Id": "7EDA:3B0A:1BB04:4B618:5CAB9095"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/repositories/deploy_keys#find.json
+++ b/test/fixture/vcr_cassettes/repositories/deploy_keys#find.json
@@ -1,0 +1,43 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/milica-nerlovic/tentacat/keys/1234"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"message\":\"Not Found\",\"documentation_url\":\"https://developer.github.com/v3/repos/keys/#get-a-deploy-key\"}",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Mon, 08 Apr 2019 18:06:13 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "106",
+        "Status": "404 Not Found",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4999",
+        "X-RateLimit-Reset": "1554750373",
+        "X-OAuth-Scopes": "admin:public_key, repo",
+        "X-Accepted-OAuth-Scopes": "repo",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Frame-Options": "deny",
+        "X-Content-Type-Options": "nosniff",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'",
+        "X-GitHub-Request-Id": "7E87:6286:35DD9:83BC4:5CAB8D94"
+      },
+      "status_code": 404,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/repositories/deploy_keys#list.json
+++ b/test/fixture/vcr_cassettes/repositories/deploy_keys#list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/milica-nerlovic/tentacat/keys"
+    },
+    "response": {
+      "binary": false,
+      "body": "[]",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Mon, 08 Apr 2019 17:58:50 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4999",
+        "X-RateLimit-Reset": "1554749930",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"c805dd7a1bd4ba32be1e8b137fec5574\"",
+        "X-OAuth-Scopes": "admin:public_key, repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Frame-Options": "deny",
+        "X-Content-Type-Options": "nosniff",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'",
+        "X-GitHub-Request-Id": "7E67:25A8:5E235:BCCBD:5CAB8BDA"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/repositories/deploy_keys#remove.json
+++ b/test/fixture/vcr_cassettes/repositories/deploy_keys#remove.json
@@ -1,0 +1,42 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/milica-nerlovic/tentacat/keys/34371109"
+    },
+    "response": {
+      "binary": false,
+      "body": "",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Mon, 08 Apr 2019 18:31:42 GMT",
+        "Content-Type": "application/octet-stream",
+        "Status": "204 No Content",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4999",
+        "X-RateLimit-Reset": "1554751902",
+        "X-OAuth-Scopes": "admin:public_key, repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Frame-Options": "deny",
+        "X-Content-Type-Options": "nosniff",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'",
+        "X-GitHub-Request-Id": "7E0E:7A6E:46FF8:B0DC0:5CAB938E"
+      },
+      "status_code": 204,
+      "type": "ok"
+    }
+  }
+]

--- a/test/repositories/deploy_keys_test.exs
+++ b/test/repositories/deploy_keys_test.exs
@@ -1,0 +1,19 @@
+defmodule Tentacat.Repositories.DeployKeysTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Repositories.DeployKeys
+
+  doctest Tentacat.Repositories.DeployKeys
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start()
+  end
+
+  test "list/3" do
+    use_cassette "repositories/deploy_keys#list" do
+      assert elem(list(@client, "milica-nerlovic", "tentacat"), 1) == []
+    end
+  end
+end

--- a/test/repositories/deploy_keys_test.exs
+++ b/test/repositories/deploy_keys_test.exs
@@ -16,4 +16,11 @@ defmodule Tentacat.Repositories.DeployKeysTest do
       assert elem(list(@client, "milica-nerlovic", "tentacat"), 1) == []
     end
   end
+
+  test "find/4" do
+    use_cassette "repositories/deploy_keys#find" do
+      {status_code, _, _} = find(@client, "milica-nerlovic", "tentacat", "1234")
+      assert status_code == 404
+    end
+  end
 end

--- a/test/repositories/deploy_keys_test.exs
+++ b/test/repositories/deploy_keys_test.exs
@@ -5,7 +5,7 @@ defmodule Tentacat.Repositories.DeployKeysTest do
 
   doctest Tentacat.Repositories.DeployKeys
 
-  @client Tentacat.Client.new(%{access_token: "youtokencomeshere"})
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
 
   setup_all do
     HTTPoison.start()
@@ -41,4 +41,10 @@ defmodule Tentacat.Repositories.DeployKeysTest do
     end
   end
 
+  test "remove/4" do
+    use_cassette "repositories/deploy_keys#remove" do
+      {status_code, _, _} = remove(@client, "milica-nerlovic", "tentacat", 34_371_109)
+      assert status_code == 204
+    end
+  end
 end

--- a/test/repositories/deploy_keys_test.exs
+++ b/test/repositories/deploy_keys_test.exs
@@ -5,7 +5,7 @@ defmodule Tentacat.Repositories.DeployKeysTest do
 
   doctest Tentacat.Repositories.DeployKeys
 
-  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+  @client Tentacat.Client.new(%{access_token: "youtokencomeshere"})
 
   setup_all do
     HTTPoison.start()
@@ -23,4 +23,22 @@ defmodule Tentacat.Repositories.DeployKeysTest do
       assert status_code == 404
     end
   end
+
+  test "create/4" do
+    use_cassette "repositories/deploy_keys#create" do
+      key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCc72ESoMRGBQJBjnUUSNo1uoRnV7PI82KtqfSLjcmj3fUB0OvVx8haMhtb7hlxKb5J7J2vLNONyRgNryUkOFTwfHpCt0TZqCKMvp9AuYyAQH2E1kbIGPQ/6BTCktGXq200Ua2hM5NNZjuCgxgMNoyxMzoSb5qChCXatQLIzbODBhyMEPwUq3PqAieirCEPIjXRr2jEAR9+xL8UnHb2e3ZcjuqZPB+yiZZSzZA5IDs3zW7RBQB6ZLoIInUWRxR41YE/2gNeUe4FwhXfxXane/4zkiNqqClE2rDo25MocVpqzP8niVuwQYPYsxEGOo/RIaQa55wvD/LMIwEaOVdbnRl7"
+      body = %{
+        "title" => "test_key",
+        "read_only" => true,
+        "key" => key
+      }
+
+      {status_code, body, _} = create(@client, "milica-nerlovic", "tentacat", body)
+      assert status_code == 201
+      assert body["read_only"] == true
+      assert body["title"] == "test_key"
+      assert body["key"] == key
+    end
+  end
+
 end


### PR DESCRIPTION
I've recently had to interface with the Repositories Deploy Keys GitHub API on an Elixir project and so I noticed the support for that is missing in `tentacat`.

This PR implement all available Deploy Keys API [endpoints](https://developer.github.com/v3/repos/keys/). I've nested the module under `Repositories`, following in the current structure.

