### PR TITLE
Add support for Repositories Contents API

### DIFF
--- a/lib/tentacat/repositories/contents.ex
+++ b/lib/tentacat/repositories/contents.ex
@@ -1,0 +1,19 @@
+defmodule Tentacat.Repositories.Contents do
+  import Tentacat
+  alias Tentacat.Client
+
+  @doc """
+  Gets the contents of a file or directory in a repository
+
+  ## Example
+      Tentacat.Repositories.Contents.content "elixir-lang", "elixir", "CHANGELOG.md"
+      Tentacat.Repositories.Contents.content client, "elixir-lang", "elixir", "CHANGELOG.md"
+
+  More info at: https://developer.github.com/v3/repos/contents/#get-contents
+  """
+  @spec content(Client.t(), binary, binary) :: Tentacat.response()
+  def content(client \\ %Client{}, owner, repo, path) do
+    get("repos/#{owner}/#{repo}/contents/#{path}", client)
+  end
+
+end

--- a/test/fixture/vcr_cassettes/repositories/contents#content.json
+++ b/test/fixture/vcr_cassettes/repositories/contents#content.json
@@ -1,0 +1,47 @@
+[
+  {
+    "request": {
+      "body": "\"\\\"\\\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/edgurgel/tentacat/contents/LICENSE"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"name\":\"LICENSE\",\"path\":\"LICENSE\",\"sha\":\"bc827228e025b120e7aebae0bb6077b3f6657c26\",\"size\":1069,\"url\":\"https://api.github.com/repos/edgurgel/tentacat/contents/LICENSE?ref=master\",\"html_url\":\"https://github.com/edgurgel/tentacat/blob/master/LICENSE\",\"git_url\":\"https://api.github.com/repos/edgurgel/tentacat/git/blobs/bc827228e025b120e7aebae0bb6077b3f6657c26\",\"download_url\":\"https://raw.githubusercontent.com/edgurgel/tentacat/master/LICENSE\",\"type\":\"file\",\"content\":\"Q29weXJpZ2h0IChjKSAyMDEzLTIwMTQgRWR1YXJkbyBHdXJnZWwgUGluaG8K\\nClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdl\\nLCB0byBhbnkgcGVyc29uIG9idGFpbmluZwphIGNvcHkgb2YgdGhpcyBzb2Z0\\nd2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUK\\nIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQg\\ncmVzdHJpY3Rpb24sIGluY2x1ZGluZwp3aXRob3V0IGxpbWl0YXRpb24gdGhl\\nIHJpZ2h0cyB0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gs\\nCmRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBv\\nZiB0aGUgU29mdHdhcmUsIGFuZCB0bwpwZXJtaXQgcGVyc29ucyB0byB3aG9t\\nIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3Qg\\ndG8KdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHly\\naWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwg\\nYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0\\naW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklE\\nRUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQ\\nUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRP\\nIFRIRSBXQVJSQU5USUVTIE9GCk1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBG\\nT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4g\\nSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUIEhP\\nTERFUlMgQkUKTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RI\\nRVIgTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTgpPRiBDT05UUkFD\\nVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9S\\nIElOIENPTk5FQ1RJT04KV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBP\\nUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==\\n\",\"encoding\":\"base64\",\"_links\":{\"self\":\"https://api.github.com/repos/edgurgel/tentacat/contents/LICENSE?ref=master\",\"git\":\"https://api.github.com/repos/edgurgel/tentacat/git/blobs/bc827228e025b120e7aebae0bb6077b3f6657c26\",\"html\":\"https://github.com/edgurgel/tentacat/blob/master/LICENSE\"}}",
+      "headers": {
+        "Date": "Sun, 21 Jul 2019 11:36:15 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2233",
+        "Server": "GitHub.com",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "5000",
+        "X-RateLimit-Remaining": "4991",
+        "X-RateLimit-Reset": "1563712575",
+        "Cache-Control": "private, max-age=60, s-maxage=60",
+        "Vary": "Accept, Authorization, Cookie, X-GitHub-OTP",
+        "ETag": "\"bc827228e025b120e7aebae0bb6077b3f6657c26\"",
+        "Last-Modified": "Thu, 25 Apr 2019 08:41:40 GMT",
+        "X-OAuth-Scopes": "repo",
+        "X-Accepted-OAuth-Scopes": "",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
+        "Access-Control-Allow-Origin": "*",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Frame-Options": "deny",
+        "X-Content-Type-Options": "nosniff",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'",
+        "X-GitHub-Request-Id": "C0CB:052F:3604D6:42A554:5D344E2E"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/test/repositories/contents_test.exs
+++ b/test/repositories/contents_test.exs
@@ -1,0 +1,21 @@
+defmodule Tentacat.Repositories.ContributorsTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  import Tentacat.Repositories.Contents
+
+  doctest Tentacat.Repositories.Contents
+
+  @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
+
+  setup_all do
+    HTTPoison.start()
+  end
+
+  test "content/4" do
+    use_cassette "repositories/contents#content" do
+      {_, body, _} = content(@client, "edgurgel", "tentacat", "LICENSE")
+
+      assert String.slice(:base64.mime_decode(body["content"]), 0, 9) == "Copyright"
+    end
+  end
+end


### PR DESCRIPTION
> Gets the contents of a file or directory in a repository

Doc: https://developer.github.com/v3/repos/contents/#get-contents

Do you want to be able to manage options like `ref` or when it's a directory (we get a listing).
For the last one, checking the other endpoints, it seems the philosophy is to be only an API wraper.
What about the the `ref` option then ?
