### PR TITLE
Fix a typo in Tentacat.Repositories.Contributors docs

### DIFF
--- a/lib/tentacat/repositories/contributors.ex
+++ b/lib/tentacat/repositories/contributors.ex
@@ -6,8 +6,8 @@ defmodule Tentacat.Repositories.Contributors do
   List contributors for a specific repository
 
   ## Example
-      Tentacat.Repositories.contributors.list "elixir-lang", "elixir"
-      Tentacat.Repositories.contributors.list client, "elixir-lang", "elixir"
+      Tentacat.Repositories.Contributors.list "elixir-lang", "elixir"
+      Tentacat.Repositories.Contributors.list client, "elixir-lang", "elixir"
 
   More info at: https://developer.github.com/v3/repos/#list-contributors
   """


### PR DESCRIPTION
Hey guys,

Thanks for the lib. I've just noticed there is a typo in the doc, this PR fixes it.

Cheers! 