### PR TITLE
Convert Keyword lists to Maps before encoding JSON body

### DIFF
--- a/lib/tentacat.ex
+++ b/lib/tentacat.ex
@@ -12,14 +12,6 @@ defmodule Tentacat do
 
   @type pagination_response :: {response, binary | nil, Client.auth()}
 
-  defimpl Jason.Encoder, for: Tuple do
-    def encode(tuple, opts) when is_tuple(tuple) do
-      [tuple]
-      |> Enum.into(%{})
-      |> Jason.Encode.map(opts)
-    end
-  end
-
   @spec process_response_body(binary) :: term
   def process_response_body(""), do: nil
   def process_response_body(body), do: Jason.decode!(body, deserialization_options())
@@ -94,6 +86,8 @@ defmodule Tentacat do
 
   @spec json_request(atom, binary, any, keyword, keyword) :: response
   def json_request(method, url, body \\ "", headers \\ [], options \\ []) do
+    body = if Keyword.keyword?(body), do: Map.new(body), else: body
+
     raw_request(method, url, Jason.encode!(body), headers, options)
   end
 

--- a/test/repositories_test.exs
+++ b/test/repositories_test.exs
@@ -83,7 +83,7 @@ defmodule Tentacat.RepositoriesTest do
   end
 
   test "create/3" do
-    use_cassette "repositories#create" do
+    use_cassette "repositories#create", match_requests_on: [:request_body] do
       {status, _response, _} = create(@client, "tentacat", private: false)
       assert status == 201
     end


### PR DESCRIPTION
Quick fix for #193. 

- implemented conversion in `json_request/5`
- match the request body in `Repositories.create/3` test
- removed the `Encoder` for `Tuple` as it is no longer used

I didn't implement the conversion in any of the stream or pagination functions as it would seem they are never used with a body other than the default `""`.

This fix isn't very well tested yet and is intended as a quick fix, not a long term solution. See #193 for discussion. 