### PR TITLE
Fix request body encoding

### DIFF
--- a/lib/tentacat/comments/reactions.ex
+++ b/lib/tentacat/comments/reactions.ex
@@ -27,9 +27,8 @@ defmodule Tentacat.Comments.Reactions do
   Tentacat.Comments.Reactions.create "elixir-lang", "elixir", "345434"
   More info at: https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
   """
-  @spec create(Client.t(), binary, binary, binary | integer, Keyword.t() | map) ::
-          Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, comment_id, body) do
+  @spec create(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, comment_id, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/comments/#{comment_id}/reactions", client, body)
   end
 end

--- a/lib/tentacat/commits/comments.ex
+++ b/lib/tentacat/commits/comments.ex
@@ -48,8 +48,8 @@ defmodule Tentacat.Commits.Comments do
 
   More info at: https://developer.github.com/v3/repos/comments/#create-a-commit-comment
   """
-  @spec create(Client.t(), binary, binary, binary, map | list) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, sha, body) do
+  @spec create(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, sha, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/commits/#{sha}/comments", client, body)
   end
 
@@ -82,8 +82,8 @@ defmodule Tentacat.Commits.Comments do
 
   More info at: https://developer.github.com/v3/repos/comments/#update-a-commit-comment
   """
-  @spec update(Client.t(), binary, binary, binary | integer, map | list) :: Tentacat.response()
-  def update(client \\ %Client{}, owner, repo, id, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client \\ %Client{}, owner, repo, id, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/comments/#{id}", client, body)
   end
 

--- a/lib/tentacat/contents.ex
+++ b/lib/tentacat/contents.ex
@@ -68,8 +68,8 @@ defmodule Tentacat.Contents do
 
   More info at: https://developer.github.com/v3/repos/contents/#create-a-file
   """
-  @spec create(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def create(client, owner, repo, path, body) do
+  @spec create(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, path, body) when is_map(body) do
     put("repos/#{owner}/#{repo}/contents/#{path}", client, body)
   end
 
@@ -95,8 +95,8 @@ defmodule Tentacat.Contents do
 
   More info at: https://developer.github.com/v3/repos/contents/#update-a-file
   """
-  @spec update(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def update(client, owner, repo, path, body) do
+  @spec update(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def update(client, owner, repo, path, body) when is_map(body) do
     put("repos/#{owner}/#{repo}/contents/#{path}", client, body)
   end
 
@@ -121,8 +121,8 @@ defmodule Tentacat.Contents do
 
   More info at: https://developer.github.com/v3/repos/contents/#delete-a-file
   """
-  @spec remove(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def remove(client, owner, repo, path, body) do
+  @spec remove(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def remove(client, owner, repo, path, body) when is_map(body) do
     delete("repos/#{owner}/#{repo}/contents/#{path}", client, body)
   end
 end

--- a/lib/tentacat/emails.ex
+++ b/lib/tentacat/emails.ex
@@ -27,7 +27,7 @@ defmodule Tentacat.Users.Emails do
   """
   @spec create(Client.t(), [binary]) :: Tentacat.response()
   def create(client, emails) do
-    post("user/emails", client, emails)
+    post("user/emails", client, %{emails: emails})
   end
 
   @doc """

--- a/lib/tentacat/gists.ex
+++ b/lib/tentacat/gists.ex
@@ -110,8 +110,8 @@ defmodule Tentacat.Gists do
 
   More info at: https://developer.github.com/v3/gists/#create-a-gist
   """
-  @spec create(Client.t(), list | map) :: Tentacat.response()
-  def create(client, body) do
+  @spec create(Client.t(), map) :: Tentacat.response()
+  def create(client, body) when is_map(body) do
     post("gists", client, body)
   end
 
@@ -139,8 +139,8 @@ defmodule Tentacat.Gists do
 
   More info at: https://developer.github.com/v3/gists/#edit-a-gist
   """
-  @spec edit(Client.t(), binary, list | map) :: Tentacat.response()
-  def edit(client, gist_id, body) do
+  @spec edit(Client.t(), binary, map) :: Tentacat.response()
+  def edit(client, gist_id, body) when is_map(body) do
     patch("gists/#{gist_id}", client, body)
   end
 

--- a/lib/tentacat/git/blobs.ex
+++ b/lib/tentacat/git/blobs.ex
@@ -32,8 +32,8 @@ defmodule Tentacat.Git.Blobs do
 
   More info at: https://developer.github.com/v3/git/blobs/#create-a-blob
   """
-  @spec create(Client.t(), binary, binary, map | list) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/git/blobs", client, body)
   end
 end

--- a/lib/tentacat/hooks.ex
+++ b/lib/tentacat/hooks.ex
@@ -43,8 +43,8 @@ defmodule Tentacat.Hooks do
 
   More info at: http://developer.github.com/v3/repos/hooks/#create-a-hook
   """
-  @spec create(Client.t(), binary, binary, list) :: Tentacat.response()
-  def create(client, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/hooks", client, body)
   end
 
@@ -65,8 +65,8 @@ defmodule Tentacat.Hooks do
 
   More info at: http://developer.github.com/v3/repos/hooks/#edit-a-hook
   """
-  @spec update(Client.t(), binary, binary, binary | integer, list) :: Tentacat.response()
-  def update(client, owner, repo, hook_id, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client, owner, repo, hook_id, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/hooks/#{hook_id}", client, body)
   end
 

--- a/lib/tentacat/issues/comments.ex
+++ b/lib/tentacat/issues/comments.ex
@@ -89,8 +89,8 @@ defmodule Tentacat.Issues.Comments do
 
   https://developer.github.com/v3/issues/comments/#create-a-comment
   """
-  @spec create(Client.t(), binary, binary, binary | integer, list | map) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, issue_id, body) do
+  @spec create(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, issue_id, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/issues/#{issue_id}/comments", client, body)
   end
 
@@ -110,8 +110,8 @@ defmodule Tentacat.Issues.Comments do
 
   https://developer.github.com/v3/issues/comments/#edit-a-comment
   """
-  @spec update(Client.t(), binary, binary, binary | integer, list | map) :: Tentacat.response()
-  def update(client \\ %Client{}, owner, repo, comment_id, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client \\ %Client{}, owner, repo, comment_id, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/issues/comments/#{comment_id}", client, body)
   end
 

--- a/lib/tentacat/issues/comments/reactions.ex
+++ b/lib/tentacat/issues/comments/reactions.ex
@@ -31,9 +31,9 @@ defmodule Tentacat.Issues.Comments.Reactions do
 
   More info at: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
   """
-  @spec create(Client.t(), binary, binary, binary | integer, Keyword.t() | map) ::
+  @spec create(Client.t(), binary, binary, binary | integer, map) ::
           Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, comment_id, body) do
+  def create(client \\ %Client{}, owner, repo, comment_id, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/issues/comments/#{comment_id}/reactions", client, body)
   end
 end

--- a/lib/tentacat/issues/issues.ex
+++ b/lib/tentacat/issues/issues.ex
@@ -52,11 +52,11 @@ defmodule Tentacat.Issues do
 
   Possible values for `body`:
 
-  * [title: "title of issue"] (required)
-  * [body: "body of issue"]
-  * [assignee: "username"]
-  * [milestone: 4]
-  * [labels: ["bug", "frontend"]]
+  * %{title: "title of issue"} (required)
+  * %{body: "body of issue"}
+  * %{assignee: "username"}
+  * %{milestone: 4}
+  * %{labels: ["bug", "frontend"]}
 
   ## Example
 
@@ -65,8 +65,8 @@ defmodule Tentacat.Issues do
 
   More info at: https://developer.github.com/v3/issues/#create-an-issue
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/issues", client, body)
   end
 
@@ -75,12 +75,12 @@ defmodule Tentacat.Issues do
 
   Possible values for `body`:
 
-  * [title: "title of issue"]
-  * [body: "body of issue"]
-  * [assignee: "username"]
-  * [state: "closed"]
-  * [milestone: 4]
-  * [labels: ["bug", "frontend"]]
+  * %{title: "title of issue"}
+  * %{body: "body of issue"}
+  * %{assignee: "username"}
+  * %{state: "closed"}
+  * %{milestone: 4}
+  * %{labels: ["bug", "frontend"]}
 
   ## Example
 
@@ -89,8 +89,8 @@ defmodule Tentacat.Issues do
 
   More info at: https://developer.github.com/v3/issues/#edit-an-issue
   """
-  @spec update(Client.t(), binary, binary, binary | integer, list | map) :: Tentacat.response()
-  def update(client \\ %Client{}, owner, repo, number, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client \\ %Client{}, owner, repo, number, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/issues/#{number}", client, body)
   end
 end

--- a/lib/tentacat/milestones/milestones.ex
+++ b/lib/tentacat/milestones/milestones.ex
@@ -37,10 +37,10 @@ defmodule Tentacat.Milestones do
 
   Possible values for `body`:
 
-  * ["title": "v1.0"]
-  * ["state": "open"]
-  * ["description": "Tracking milestone for version 1.0"]
-  * ["due_on": "2012-10-09T23:39:01Z"]
+  * %{"title": "v1.0"}
+  * %{"state": "open"}
+  * %{"description": "Tracking milestone for version 1.0"}
+  * %{"due_on": "2012-10-09T23:39:01Z"}
 
   ## Example
 
@@ -49,8 +49,8 @@ defmodule Tentacat.Milestones do
 
   More info at: https://developer.github.com/v3/issues/milestones/#create-a-milestone
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/milestones", client, body)
   end
 
@@ -59,10 +59,10 @@ defmodule Tentacat.Milestones do
 
   Possible values for `body`:
 
-  * ["title": "v1.0"]
-  * ["state": "open"]
-  * ["description": "Tracking milestone for version 1.0"]
-  * ["due_on": "2012-10-09T23:39:01Z"]
+  * %{"title": "v1.0"}
+  * %{"state": "open"}
+  * %{"description": "Tracking milestone for version 1.0"}
+  * %{"due_on": "2012-10-09T23:39:01Z"}
 
   ## Example
 
@@ -71,8 +71,8 @@ defmodule Tentacat.Milestones do
 
   More info at: https://developer.github.com/v3/issues/milestones/#update-a-milestone
   """
-  @spec update(Client.t(), binary, binary, binary | integer, list | map) :: Tentacat.response()
-  def update(client \\ %Client{}, owner, repo, number, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client \\ %Client{}, owner, repo, number, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/milestones/#{number}", client, body)
   end
 

--- a/lib/tentacat/organizations/hooks.ex
+++ b/lib/tentacat/organizations/hooks.ex
@@ -41,7 +41,7 @@ defmodule Tentacat.Organizations.Hooks do
   More info at: http://developer.github.com/v3/orgs/hooks/#create-a-hook
   """
   @spec create(Client.t(), binary, list) :: Tentacat.response()
-  def create(client, organization, body) do
+  def create(client, organization, body) when is_map(body) do
     post("orgs/#{organization}/hooks", client, body)
   end
 
@@ -62,8 +62,8 @@ defmodule Tentacat.Organizations.Hooks do
 
   More info at: http://developer.github.com/v3/orgs/hooks/#edit-a-hook
   """
-  @spec update(Client.t(), binary, binary | integer, list) :: Tentacat.response()
-  def update(client, organization, hook_id, body) do
+  @spec update(Client.t(), binary, binary | integer, map) :: Tentacat.response()
+  def update(client, organization, hook_id, body) when is_map(body) do
     patch("orgs/#{organization}/hooks/#{hook_id}", client, body)
   end
 

--- a/lib/tentacat/organizations/projects.ex
+++ b/lib/tentacat/organizations/projects.ex
@@ -21,17 +21,17 @@ defmodule Tentacat.Organizations.Projects do
 
   Possible values for options:
 
-  * [name: "name of project board"]
-  * [body: "description of the project"]
+  * %{name: "name of project board"}
+  * %{body: "description of the project"}
 
   ## Example
 
-    Tentacat.Organizations.Projects.create client, "elixir-lang", name: "tentacat", body: "project board for tentacat"
+    Tentacat.Organizations.Projects.create client, "elixir-lang", %{ name: "tentacat", body: "project board for tentacat"}
 
   More info at: https://developer.github.com/v3/projects/#create-an-organization-project
   """
-  @spec create(Client.t(), binary, list) :: Tentacat.response()
-  def create(client, organization, options) do
+  @spec create(Client.t(), binary, map) :: Tentacat.response()
+  def create(client, organization, options) when is_map(options) do
     post("orgs/#{organization}/projects", client, options)
   end
 end

--- a/lib/tentacat/projects.ex
+++ b/lib/tentacat/projects.ex
@@ -21,20 +21,20 @@ defmodule Tentacat.Projects do
 
   Possible values for `options`:
 
-  * [name: "name of project"]
-  * [body: "description of project"]
-  * [state: "open"]
-  * [organization_permission: "read"]
-  * [private: true]
+  * name: "name of project"
+  * body: "description of project"
+  * state: "open"
+  * organization_permission: "read"
+  * private: true
 
   ## Example
 
-      Tentcat.Projects.update client, [name: "My Board", private: true]
+      Tentacat.Projects.update client, %{name: "My Board", private: true}
 
   More info at: https://developer.github.com/v3/projects/#update-a-project
   """
-  @spec update(Client.t(), binary, Keyword.t()) :: Tentacat.response()
-  def update(client, id, options) do
+  @spec update(Client.t(), binary, map) :: Tentacat.response()
+  def update(client, id, options) when is_map(options) do
     patch("projects/#{id}", client, options)
   end
 

--- a/lib/tentacat/pulls.ex
+++ b/lib/tentacat/pulls.ex
@@ -73,8 +73,8 @@ defmodule Tentacat.Pulls do
 
   More info at: https://developer.github.com/v3/pulls/#create-a-pull-request
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/pulls", client, body)
   end
 
@@ -95,8 +95,8 @@ defmodule Tentacat.Pulls do
 
   More info at: https://developer.github.com/v3/pulls/#update-a-pull-request
   """
-  @spec update(Client.t(), binary, binary, binary | integer, list | map) :: Tentacat.response()
-  def update(client, owner, repo, number, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client, owner, repo, number, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/pulls/#{number}", client, body)
   end
 
@@ -116,8 +116,8 @@ defmodule Tentacat.Pulls do
 
   More info at: https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
   """
-  @spec merge(Client.t(), binary, binary, binary | integer, list | map) :: Tentacat.response()
-  def merge(client, owner, repo, number, body) do
+  @spec merge(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def merge(client, owner, repo, number, body) when is_map(body) do
     put("repos/#{owner}/#{repo}/pulls/#{number}/merge", client, body)
   end
 

--- a/lib/tentacat/pulls/comments.ex
+++ b/lib/tentacat/pulls/comments.ex
@@ -81,8 +81,8 @@ defmodule Tentacat.Pulls.Comments do
 
   More info at: https://developer.github.com/v3/pulls/comments/#create-a-comment
   """
-  @spec create(Client.t(), binary, binary, integer | binary, list | map) :: Tentacat.response()
-  def create(client, owner, repo, number, body) do
+  @spec create(Client.t(), binary, binary, integer | binary, map) :: Tentacat.response()
+  def create(client, owner, repo, number, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/pulls/#{number}/comments", client, body)
   end
 
@@ -95,8 +95,8 @@ defmodule Tentacat.Pulls.Comments do
 
   More info at: https://developer.github.com/v3/pulls/comments/#edit-a-comment
   """
-  @spec update(Client.t(), binary, binary, binary | integer, list) :: Tentacat.response()
-  def update(client, owner, repo, comment_id, body) do
+  @spec update(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def update(client, owner, repo, comment_id, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/pulls/comments/#{comment_id}", client, body)
   end
 

--- a/lib/tentacat/pulls/comments/reactions.ex
+++ b/lib/tentacat/pulls/comments/reactions.ex
@@ -31,9 +31,8 @@ defmodule Tentacat.Pulls.Comments.Reactions do
 
   More info at: https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment
   """
-  @spec create(Client.t(), binary, binary, binary | integer, Keyword.t() | map) ::
-          Tentacat.response()
-  def create(client, owner, repo, comment_id, body) do
+  @spec create(Client.t(), binary, binary, binary | integer, map) :: Tentacat.response()
+  def create(client, owner, repo, comment_id, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/pulls/comments/#{comment_id}/reactions", client, body)
   end
 end

--- a/lib/tentacat/pulls/reviews.ex
+++ b/lib/tentacat/pulls/reviews.ex
@@ -39,7 +39,7 @@ defmodule Tentacat.Pulls.Reviews do
   More info at: https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
   """
   @spec create(Client.t(), binary, binary, binary | integer, map()) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, number, body) do
+  def create(client \\ %Client{}, owner, repo, number, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/pulls/#{number}/reviews", client, body)
   end
 end

--- a/lib/tentacat/references.ex
+++ b/lib/tentacat/references.ex
@@ -48,8 +48,8 @@ defmodule Tentacat.References do
 
   More info at: https://developer.github.com/v3/git/refs/#create-a-reference
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/git/refs", client, body)
   end
 
@@ -69,8 +69,8 @@ defmodule Tentacat.References do
 
   More info at: https://developer.github.com/v3/git/refs/#update-a-reference
   """
-  @spec update(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def update(client, owner, repo, ref, body) do
+  @spec update(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def update(client, owner, repo, ref, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/git/refs/#{ref}", client, body)
   end
 

--- a/lib/tentacat/releases.ex
+++ b/lib/tentacat/releases.ex
@@ -54,10 +54,11 @@ defmodule Tentacat.Releases do
 
   More info at: http://developer.github.com/v3/repos/releases/#create-a-release
   """
-  @spec create(Client.t(), binary, binary, binary, list) :: Tentacat.response()
-  def create(client \\ %Client{}, tag_name, owner, repo, options \\ [])
-      when is_binary(tag_name) do
-    body = Keyword.merge(options, tag_name: tag_name)
+  @spec create(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, tag_name, owner, repo, options \\ %{})
+      when is_map(options) and
+             is_binary(tag_name) do
+    body = Map.merge(options, %{tag_name: tag_name})
     post("repos/#{owner}/#{repo}/releases", client, body)
   end
 
@@ -79,8 +80,9 @@ defmodule Tentacat.Releases do
 
   More info at: http://developer.github.com/v3/repos/releases/#edit-a-release
   """
-  @spec edit(Client.t(), integer, binary, binary, list) :: Tentacat.response()
-  def edit(client \\ %Client{}, id, owner, repo, options \\ []) when is_integer(id) do
+  @spec edit(Client.t(), integer, binary, binary, map) :: Tentacat.response()
+  def edit(client \\ %Client{}, id, owner, repo, options \\ %{})
+      when is_integer(id) and is_map(options) do
     patch("repos/#{owner}/#{repo}/releases/#{id}", client, options)
   end
 

--- a/lib/tentacat/repositories.ex
+++ b/lib/tentacat/repositories.ex
@@ -86,31 +86,31 @@ defmodule Tentacat.Repositories do
 
   Possible values for `options`:
 
-  * [description: "Simple Elixir wrapper for the GitHub API"]
-  * [homepage: "http://www.github.com/edgurgel/tentacat"]
-  * [private: false]
-  * [has_issues: true]
-  * [has_wiki: false]
-  * [has_downloads: true]
-  * [team_id: 123]
-  * [auto_init: false]
-  * [gitignore_template: "Haskell"]
-  * [license_template: "mit"]j
+  * %{description: "Simple Elixir wrapper for the GitHub API"}
+  * %{homepage: "http://www.github.com/edgurgel/tentacat"}
+  * %{private: false}
+  * %{has_issues: true}
+  * %{has_wiki: false}
+  * %{has_downloads: true}
+  * %{team_id: 123}
+  * %{auto_init: false}
+  * %{gitignore_template: "Haskell"}
+  * %{license_template: "mit"}j
 
   ## Example
 
-      Tentacat.Repositories.create(client, "tentacat", private: false)
+      Tentacat.Repositories.create(client, "tentacat", %{private: false})
 
   More info at: https://developer.github.com/v3/repos/#create
   """
-  @spec create(Client.t(), binary, list) :: Tentacat.response()
-  def create(client, repo, options \\ []) do
-    post("user/repos", client, List.flatten([name: repo], options))
+  @spec create(Client.t(), binary, map) :: Tentacat.response()
+  def create(client, repo, options \\ %{}) when is_map(options) do
+    post("user/repos", client, Map.merge(%{name: repo}, options))
   end
 
   @spec org_create(Client.t(), binary, binary, list) :: Tentacat.response()
-  def org_create(client, org, repo, options \\ []) do
-    post("orgs/#{org}/repos", client, List.flatten([name: repo], options))
+  def org_create(client, org, repo, options \\ %{}) when is_map(options) do
+    post("orgs/#{org}/repos", client, Map.merge(%{name: repo}, options))
   end
 
   @doc """

--- a/lib/tentacat/repositories/branches.ex
+++ b/lib/tentacat/repositories/branches.ex
@@ -75,8 +75,8 @@ defmodule Tentacat.Repositories.Branches do
 
   More info at: https://developer.github.com/v3/repos/branches/#update-branch-protection
   """
-  @spec update_protection(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def update_protection(client \\ %Client{}, owner, repo, branch, body) do
+  @spec update_protection(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def update_protection(client \\ %Client{}, owner, repo, branch, body) when is_map(body) do
     put("repos/#{owner}/#{repo}/branches/#{branch}/protection", client, body)
   end
 end

--- a/lib/tentacat/repositories/deploy_keys.ex
+++ b/lib/tentacat/repositories/deploy_keys.ex
@@ -45,7 +45,7 @@ defmodule Tentacat.Repositories.DeployKeys do
   More info at: https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key
   """
   @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
-  def create(client, owner, repo, body) do
+  def create(client, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/keys", client, body)
   end
 

--- a/lib/tentacat/repositories/deployments.ex
+++ b/lib/tentacat/repositories/deployments.ex
@@ -35,8 +35,8 @@ defmodule Tentacat.Repositories.Deployments do
 
   More info at: https://developer.github.com/v3/repos/deployments/#create-a-deployment
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/deployments", client, body)
   end
 
@@ -73,8 +73,8 @@ defmodule Tentacat.Repositories.Deployments do
 
   More info at: https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
   """
-  @spec create_status(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def create_status(client, owner, repo, id, body) do
+  @spec create_status(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def create_status(client, owner, repo, id, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/deployments/#{id}/statuses", client, body)
   end
 end

--- a/lib/tentacat/repositories/forks.ex
+++ b/lib/tentacat/repositories/forks.ex
@@ -26,8 +26,8 @@ defmodule Tentacat.Repositories.Forks do
 
   More info at: https://developer.github.com/v3/repos/forks/#create-a-fork
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/forks", client, body)
   end
 end

--- a/lib/tentacat/repositories/labels.ex
+++ b/lib/tentacat/repositories/labels.ex
@@ -35,8 +35,8 @@ defmodule Tentacat.Repositories.Labels do
 
   Possible values for `body`:
 
-  * [name: "name of label"] (required)
-  * [color: "color of label"] (required)
+  * %{name: "name of label"} (required)
+  * %{color: "color of label"} (required)
 
   ## Example
 
@@ -44,8 +44,8 @@ defmodule Tentacat.Repositories.Labels do
 
   More info at: https://developer.github.com/v3/issues/labels/#create-a-label
   """
-  @spec create(Client.t(), binary, binary, list | map) :: Tentacat.response()
-  def create(client \\ %Client{}, owner, repo, body) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client \\ %Client{}, owner, repo, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/labels", client, body)
   end
 
@@ -54,8 +54,8 @@ defmodule Tentacat.Repositories.Labels do
 
   Possible values for `body`:
 
-  * [name: "name of label"] (required)
-  * [color: "color of label"] (required)
+  * %{name: "name of label"} (required)
+  * %{color: "color of label"} (required)
 
   ## Example
 
@@ -63,8 +63,8 @@ defmodule Tentacat.Repositories.Labels do
 
   More info at: https://developer.github.com/v3/issues/labels/#update-a-label
   """
-  @spec update(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def update(client \\ %Client{}, owner, repo, name, body) do
+  @spec update(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def update(client \\ %Client{}, owner, repo, name, body) when is_map(body) do
     patch("repos/#{owner}/#{repo}/labels/#{name}", client, body)
   end
 

--- a/lib/tentacat/repositories/projects.ex
+++ b/lib/tentacat/repositories/projects.ex
@@ -21,17 +21,17 @@ defmodule Tentacat.Repositories.Projects do
 
   Possible values for options:
 
-  * [name: "name of project board"]
-  * [body: "description of the project"]
+  * %{name: "name of project board"}
+  * %{body: "description of the project"}
 
   ## Example
 
-    Tentacat.Repositories.Projects.create client, "elixir-lang", "elixir", name: "tentacat", body: "project board for tentacat"
+    Tentacat.Repositories.Projects.create client, "elixir-lang", "elixir", %{name: "tentacat", body: "project board for tentacat"}
 
   More info at: https://developer.github.com/v3/projects/#create-a-repository-project
   """
-  @spec create(Client.t(), binary, binary, list) :: Tentacat.response()
-  def create(client, owner, repo, options) do
+  @spec create(Client.t(), binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, options) when is_map(options) do
     post("repos/#{owner}/#{repo}/projects", client, options)
   end
 end

--- a/lib/tentacat/repositories/statuses.ex
+++ b/lib/tentacat/repositories/statuses.ex
@@ -53,8 +53,8 @@ defmodule Tentacat.Repositories.Statuses do
 
   More info at: https://developer.github.com/v3/repos/statuses/#create-a-status
   """
-  @spec create(Client.t(), binary, binary, binary, list | map) :: Tentacat.response()
-  def create(client, owner, repo, sha, body) do
+  @spec create(Client.t(), binary, binary, binary, map) :: Tentacat.response()
+  def create(client, owner, repo, sha, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/statuses/#{sha}", client, body)
   end
 end

--- a/lib/tentacat/trees.ex
+++ b/lib/tentacat/trees.ex
@@ -55,8 +55,8 @@ defmodule Tentacat.Trees do
 
   More info at: https://developer.github.com/v3/git/trees/#create-a-tree
   """
-  @spec create(binary, binary, list | map, Client.t()) :: Tentacat.response()
-  def create(owner, repo, body, client) do
+  @spec create(binary, binary, map, Client.t()) :: Tentacat.response()
+  def create(owner, repo, body, client) when is_map(body) do
     post("repos/#{owner}/#{repo}/git/trees", client, body)
   end
 end

--- a/lib/tentacat/users/keys.ex
+++ b/lib/tentacat/users/keys.ex
@@ -56,7 +56,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec create(Client.t(), binary, binary) :: Tentacat.response()
   def create(client, title, key) do
-    post("user/keys", client, title: title, key: key)
+    post("user/keys", client, %{title: title, key: key})
   end
 
   @doc """
@@ -70,7 +70,7 @@ defmodule Tentacat.Users.Keys do
   """
   @spec update(Client.t(), integer, binary, binary) :: Tentacat.response()
   def update(client, id, title, key) do
-    patch("user/keys/#{id}", client, title: title, key: key)
+    patch("user/keys/#{id}", client, %{title: title, key: key})
   end
 
   @doc """

--- a/test/comments/reactions_test.exs
+++ b/test/comments/reactions_test.exs
@@ -22,7 +22,7 @@ defmodule Tentacat.Comments.ReactionsTest do
       "content" => "heart"
     }
 
-    use_cassette "comments/reactions#create" do
+    use_cassette "comments/reactions#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "1", body)
       assert status_code == 201
     end

--- a/test/commits/comments_test.exs
+++ b/test/commits/comments_test.exs
@@ -43,7 +43,7 @@ defmodule Tentacat.Commits.CommentsTest do
       "position" => 1
     }
 
-    use_cassette "commits/comments#create" do
+    use_cassette "commits/comments#create", match_requests_on: [:request_body] do
       {status_code, _, _} =
         create(
           @client,
@@ -62,7 +62,7 @@ defmodule Tentacat.Commits.CommentsTest do
       "body" => ":sheep: :lv:"
     }
 
-    use_cassette "commits/comments#update" do
+    use_cassette "commits/comments#update", match_requests_on: [:request_body] do
       {_, %{"id" => commit_id}, _} =
         update(@client, "soudqwiggle", "elixir-conspiracy", 15_079_374, body)
 

--- a/test/commits_test.exs
+++ b/test/commits_test.exs
@@ -7,10 +7,6 @@ defmodule Tentacat.CommitsTest do
 
   @client Tentacat.Client.new(%{access_token: "yourtokencomeshere"})
 
-  #  setup_all do
-  #    HTTPoison.start
-  #  end
-
   test "list/3" do
     use_cassette "commits#list" do
       assert {200, [], _} = list(@client, "soudqwiggle", "elixir-conspiracy")
@@ -18,7 +14,7 @@ defmodule Tentacat.CommitsTest do
   end
 
   test "filter/4" do
-    use_cassette "commits#filter" do
+    use_cassette "commits#filter", match_requests_on: [:query] do
       {_, [%{"sha" => sha}], _} =
         filter(@client, "soudqwiggle", "elixir-conspiracy", %{
           sha: "09fe12ca25d0440f143ab331e4684a8622d6e4e5"

--- a/test/contents_test.exs
+++ b/test/contents_test.exs
@@ -43,7 +43,7 @@ defmodule Tentacat.ContentsTest do
       "branch" => "master"
     }
 
-    use_cassette "contents#create" do
+    use_cassette "contents#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "README.md", body)
       assert status_code == 201
     end
@@ -61,7 +61,7 @@ defmodule Tentacat.ContentsTest do
       "branch" => "master"
     }
 
-    use_cassette "contents#update" do
+    use_cassette "contents#update", match_requests_on: [:request_body] do
       {_, %{"commit" => %{"sha" => sha}}, _} =
         update(@client, "soudqwiggle", "elixir-conspiracy", "README.md", body)
 
@@ -80,7 +80,7 @@ defmodule Tentacat.ContentsTest do
       "branch" => "master"
     }
 
-    use_cassette "contents#remove" do
+    use_cassette "contents#remove", match_requests_on: [:request_body] do
       {_, %{"commit" => %{"sha" => sha}}, _} =
         remove(@client, "soudqwiggle", "elixir-conspiracy", "README.md", body)
 

--- a/test/fixture/vcr_cassettes/commits#filter.json
+++ b/test/fixture/vcr_cassettes/commits#filter.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "\"\\\"\\\"\"",
+      "body": "",
       "headers": {
         "User-agent": "tentacat",
         "Authorization": "token yourtokencomeshere"

--- a/test/fixture/vcr_cassettes/gists#edit.json
+++ b/test/fixture/vcr_cassettes/gists#edit.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"description\":\"Hello World Examples\",\"files\":{\"hello_python.txt\":null,\"hello_ruby.txt\":{\"content\":\"Run `ruby hello.rb` or `python hello.py` to print Hello World\",\"filename\":\"hello.md\"},\"new_file.txt\":{\"content\":\"This is a new placeholder file.\"}}}",
+      "body": "{\"description\":\"Hello World Examples\",\"files\":{\"hello_world_python.txt\":null,\"hello_world_ruby.txt\":{\"content\":\"Run `ruby hello.rb` or `python hello.py` to print Hello World\",\"filename\":\"hello.md\"},\"new_file.txt\":{\"content\":\"This is a new placeholder file.\"}}}",
       "headers": {
         "User-agent": "tentacat",
         "Authorization": "token 8e663c8614ced27c09b963f806ac46776a29db50"

--- a/test/fixture/vcr_cassettes/organizations/projects#create.json
+++ b/test/fixture/vcr_cassettes/organizations/projects#create.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"name\":\"tentacat\",\"body\":\"my new project\"}",
+      "body": "{\"body\":\"my new project\",\"name\":\"tentacat\"}",
       "headers": {
         "Accept": "application/vnd.github.inertia-preview+json",
         "User-agent": "tentacat",

--- a/test/fixture/vcr_cassettes/pulls/comments/reactions#create.json
+++ b/test/fixture/vcr_cassettes/pulls/comments/reactions#create.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"content\":\"heart\"}",
+      "body": "{\"content\":\":+1:\"}",
       "headers": {
         "User-agent": "tentacat",
         "Authorization": "token yourtokencomeshere"

--- a/test/fixture/vcr_cassettes/repositories#org_create.json
+++ b/test/fixture/vcr_cassettes/repositories#org_create.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"name\":\"tentacat\"}",
+      "body": "{\"name\":\"tentacat\",\"private\":false}",
       "headers": {
         "User-agent": "tentacat",
         "Authorization": "token yourtokencomeshere"

--- a/test/fixture/vcr_cassettes/repositories/labels#create.json
+++ b/test/fixture/vcr_cassettes/repositories/labels#create.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"name\":\"WIP\",\"color\":\"123456\"}",
+      "body": "{\"color\":\"123456\",\"name\":\"WIP\"}",
       "headers": {
         "User-agent": "tentacat"
       },

--- a/test/fixture/vcr_cassettes/repositories/projects#create.json
+++ b/test/fixture/vcr_cassettes/repositories/projects#create.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"name\":\"tentacat\",\"body\":\"my new project\"}",
+      "body": "{\"body\":\"my new project\",\"name\":\"tentacat\"}",
       "headers": {
         "Accept": "application/vnd.github.inertia-preview+json",
         "User-agent": "tentacat",

--- a/test/fixture/vcr_cassettes/users/keys#create.json
+++ b/test/fixture/vcr_cassettes/users/keys#create.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"title\":\"test key\",\"key\":\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyRrmeVAhXGZzlS41WQGiJ5krjn3LmUBkoInDxRT0BRk9B8BT6HXHJubcrzCbhJi2NR7/h89xOlQ8g8/cXjonHVeUvcXib76WwnMVyOA1oUYELlo+iMREXPOe2Y4n+kToj2vavF9mClYsZ8fd34B/4Wpn+laFyK1dopo0tfkxxzX7GQs1smawzXg8Vz7tp/2TAuyiDqLKmiNGEhJDbCg2ZSqf1YtNPgKR+QDzeJvBWLhn9AW9BiLfBmuFVEcGE39ydIF6zmtpliZRjVHD3q53TauAsqY4MFDRRVhavlZiVFct+IYduYZqSFr7593Huyyj8EtMmnn7qufW3uKTqJR+47I3V4ASwbZp+Uf2WYWOtxufIEsy9NwU9GLe78ko89MPykrHvas3vAyYvWG85duuc0xkOtlXfdbKKyNN0CBziQ24boRVpwQbY0xn6TemxNXvObYDSrqUpZ6J/g2VkWfX/SRz96qGXS9beBPowzzphvbDo0SrXGm7lw1f0SyzPtteeAgxKUKSPrpFsO9ZWgW5owGhBZSLEpnvuF6QxyXptKToBp4/mKA1OmeXsVAdJ2vQf+WKn2CNRkctCsjX1FEY4r09/15qgpz4aaMBUfz+Nlf4YKZU9yBNZqZqVCuvY/QqLsOpeb6IzgbBaxuQ9Jlpu2JgzMst0ArBNkPI3ER6ppQ== your_email@example.com \"}",
+      "body": "{\"key\":\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCyRrmeVAhXGZzlS41WQGiJ5krjn3LmUBkoInDxRT0BRk9B8BT6HXHJubcrzCbhJi2NR7/h89xOlQ8g8/cXjonHVeUvcXib76WwnMVyOA1oUYELlo+iMREXPOe2Y4n+kToj2vavF9mClYsZ8fd34B/4Wpn+laFyK1dopo0tfkxxzX7GQs1smawzXg8Vz7tp/2TAuyiDqLKmiNGEhJDbCg2ZSqf1YtNPgKR+QDzeJvBWLhn9AW9BiLfBmuFVEcGE39ydIF6zmtpliZRjVHD3q53TauAsqY4MFDRRVhavlZiVFct+IYduYZqSFr7593Huyyj8EtMmnn7qufW3uKTqJR+47I3V4ASwbZp+Uf2WYWOtxufIEsy9NwU9GLe78ko89MPykrHvas3vAyYvWG85duuc0xkOtlXfdbKKyNN0CBziQ24boRVpwQbY0xn6TemxNXvObYDSrqUpZ6J/g2VkWfX/SRz96qGXS9beBPowzzphvbDo0SrXGm7lw1f0SyzPtteeAgxKUKSPrpFsO9ZWgW5owGhBZSLEpnvuF6QxyXptKToBp4/mKA1OmeXsVAdJ2vQf+WKn2CNRkctCsjX1FEY4r09/15qgpz4aaMBUfz+Nlf4YKZU9yBNZqZqVCuvY/QqLsOpeb6IzgbBaxuQ9Jlpu2JgzMst0ArBNkPI3ER6ppQ== your_email@example.com \",\"title\":\"test key\"}",
       "headers": {
         "User-agent": "tentacat",
         "Authorization": "token yourtokencomeshere"

--- a/test/fixture/vcr_cassettes/users/keys#update.json
+++ b/test/fixture/vcr_cassettes/users/keys#update.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "{\"title\":\"updated test key\",\"key\":\"ssh-rsa AAA...\"}",
+      "body": "{\"key\":\"ssh-rsa AAA...\",\"title\":\"updated test key\"}",
       "headers": {
         "User-agent": "tentacat",
         "Authorization": "token yourtokencomeshere"

--- a/test/gists_test.exs
+++ b/test/gists_test.exs
@@ -62,7 +62,7 @@ defmodule Tentacat.GistsTest do
   end
 
   test "create/2" do
-    use_cassette "gists#create" do
+    use_cassette "gists#create", match_requests_on: [:request_body] do
       body = %{
         "files" => %{
           "hello.rb" => %{"content" => "puts 'Hello World'"},
@@ -78,7 +78,7 @@ defmodule Tentacat.GistsTest do
   end
 
   test "edit/3" do
-    use_cassette "gists#edit" do
+    use_cassette "gists#edit", match_requests_on: [:request_body] do
       body = %{
         "description" => "Hello World Examples",
         "files" => %{

--- a/test/git/blobs_test.exs
+++ b/test/git/blobs_test.exs
@@ -12,7 +12,7 @@ defmodule Tentacat.Git.BlobsTest do
   end
 
   test "create/3" do
-    use_cassette "git/blob#create" do
+    use_cassette "git/blob#create", match_requests_on: [:request_body] do
       body = %{
         "content" => "Woop!",
         "encoding" => "utf-8"

--- a/test/hooks_test.exs
+++ b/test/hooks_test.exs
@@ -25,7 +25,7 @@ defmodule Tentacat.HooksTest do
   end
 
   test "create/4" do
-    use_cassette "hooks#create" do
+    use_cassette "hooks#create", match_requests_on: [:request_body] do
       body = %{
         "name" => "web",
         "active" => true,
@@ -47,7 +47,7 @@ defmodule Tentacat.HooksTest do
       "add_events" => ["issue"]
     }
 
-    use_cassette "hooks#update" do
+    use_cassette "hooks#update", match_requests_on: [:request_body] do
       {_, %{"active" => active}, _} =
         update(@client, "soudqwiggle", "elixir-conspiracy", 6_736_758, body)
 

--- a/test/issues/comments_test.exs
+++ b/test/issues/comments_test.exs
@@ -55,7 +55,7 @@ defmodule Tentacat.Issues.CommentsTest do
   test "create/5" do
     body = %{"body" => "woop!"}
 
-    use_cassette "issues/comments#create" do
+    use_cassette "issues/comments#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "3", body)
       assert status_code == 201
     end
@@ -64,7 +64,7 @@ defmodule Tentacat.Issues.CommentsTest do
   test "update/5" do
     body = %{"body" => "up!"}
 
-    use_cassette "issues/comments#update" do
+    use_cassette "issues/comments#update", match_requests_on: [:request_body] do
       {_, %{"body" => comment}, _} = update(@client, "lest", "test-repo", 253_744_502, body)
       assert comment == "up!"
     end

--- a/test/issues/issues_test.exs
+++ b/test/issues/issues_test.exs
@@ -18,7 +18,7 @@ defmodule Tentacat.IssuesTest do
   end
 
   test "filter/4" do
-    use_cassette "issues/issues#filter" do
+    use_cassette "issues/issues#filter", match_requests_on: [:query] do
       assert elem(filter(@client, "soudqwiggle", "elixir-conspiracy", %{"state" => "open"}), 1) ==
                []
     end
@@ -36,7 +36,7 @@ defmodule Tentacat.IssuesTest do
       "title" => "Something broke"
     }
 
-    use_cassette "issues/issues#create" do
+    use_cassette "issues/issues#create", match_requests_on: [:request_body] do
       {status_code, %{"title" => title}, _} =
         create(@client, "soudqwiggle", "elixir-conspiracy", body)
 
@@ -50,7 +50,7 @@ defmodule Tentacat.IssuesTest do
       "state" => "closed"
     }
 
-    use_cassette "issues/issues#update" do
+    use_cassette "issues/issues#update", match_requests_on: [:request_body] do
       {_, %{"state" => state}, _} = update(@client, "soudqwiggle", "elixir-conspiracy", "3", body)
       assert state == "closed"
     end

--- a/test/milestones/milestones_test.exs
+++ b/test/milestones/milestones_test.exs
@@ -24,7 +24,7 @@ defmodule Tentacat.MilestonesTest do
   end
 
   test "create/4" do
-    use_cassette "milesones/milestones#create" do
+    use_cassette "milesones/milestones#create", match_requests_on: [:request_body] do
       body = %{
         "title" => "Amazing new Readme",
         "state" => "open"
@@ -36,7 +36,7 @@ defmodule Tentacat.MilestonesTest do
   end
 
   test "update/5" do
-    use_cassette "milesones/milestones#update" do
+    use_cassette "milesones/milestones#update", match_requests_on: [:request_body] do
       body = %{
         "state" => "closed"
       }

--- a/test/organizations/hooks_test.exs
+++ b/test/organizations/hooks_test.exs
@@ -25,7 +25,7 @@ defmodule Tentacat.Organizations.HooksTest do
   end
 
   test "create/3" do
-    use_cassette "organizations/hooks#create" do
+    use_cassette "organizations/hooks#create", match_requests_on: [:request_body] do
       body = %{
         "name" => "web",
         "active" => true,
@@ -47,7 +47,7 @@ defmodule Tentacat.Organizations.HooksTest do
       "add_events" => ["issue"]
     }
 
-    use_cassette "organizations/hooks#update" do
+    use_cassette "organizations/hooks#update", match_requests_on: [:request_body] do
       {_, %{"active" => active}, _} = update(@client, "tentatest", 6_736_758, body)
       assert active == false
     end

--- a/test/organizations/projects_test.exs
+++ b/test/organizations/projects_test.exs
@@ -25,9 +25,9 @@ defmodule Tentacat.Organizations.ProjectsTest do
   end
 
   test "create/3" do
-    use_cassette "organizations/projects#create" do
+    use_cassette "organizations/projects#create", match_requests_on: [:request_body] do
       {status, _response, _} =
-        create(@client, "achiuchiutrain", name: "tentacat", body: "my new project")
+        create(@client, "achiuchiutrain", %{name: "tentacat", body: "my new project"})
 
       assert status == 201
     end

--- a/test/projects_test.exs
+++ b/test/projects_test.exs
@@ -25,8 +25,8 @@ defmodule Tentacat.ProjectsTest do
   end
 
   test "update/3" do
-    use_cassette "projects#update" do
-      {_, %{"name" => name}, _} = update(@client, 2_539_313, name: "New Demo")
+    use_cassette "projects#update", match_requests_on: [:request_body] do
+      {_, %{"name" => name}, _} = update(@client, 2_539_313, %{name: "New Demo"})
       assert name == "New Demo"
     end
   end

--- a/test/pulls/comments/reactions_test.exs
+++ b/test/pulls/comments/reactions_test.exs
@@ -22,7 +22,7 @@ defmodule Tentacat.Pulls.Comments.ReactionsTest do
       "content" => ":+1:"
     }
 
-    use_cassette "pulls/comments/reactions#create" do
+    use_cassette "pulls/comments/reactions#create", match_requests_on: [:request_body] do
       assert {201, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "1", body)
     end
   end

--- a/test/pulls/comments_test.exs
+++ b/test/pulls/comments_test.exs
@@ -24,7 +24,7 @@ defmodule Tentacat.Pulls.CommentsTest do
   end
 
   test "filter_all/4" do
-    use_cassette "pulls/comments#filter_all" do
+    use_cassette "pulls/comments#filter_all", match_requests_on: [:query] do
       elem(
         filter_all(
           @client,
@@ -54,7 +54,7 @@ defmodule Tentacat.Pulls.CommentsTest do
       "position" => 1
     }
 
-    use_cassette "pulls/comments#create" do
+    use_cassette "pulls/comments#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "1", body)
       assert status_code == 201
     end
@@ -65,7 +65,7 @@ defmodule Tentacat.Pulls.CommentsTest do
       "body" => ":+1:"
     }
 
-    use_cassette "pulls/comments#update" do
+    use_cassette "pulls/comments#update", match_requests_on: [:request_body] do
       {_, %{"id" => commit_id}, _} =
         update(@client, "soudqwiggle", "elixir-conspiracy", 47_450_612, body)
 

--- a/test/pulls/reviews_test.exs
+++ b/test/pulls/reviews_test.exs
@@ -29,7 +29,7 @@ defmodule Tentacat.Pulls.ReviewsTests do
       "event" => "COMMENT"
     }
 
-    use_cassette "pulls/reviews#create" do
+    use_cassette "pulls/reviews#create", match_requests_on: [:request_body] do
       {status_code, _, _} =
         create(@client, "sreecodeslayer", "to-test-github-app-events", "1", body)
 

--- a/test/pulls_test.exs
+++ b/test/pulls_test.exs
@@ -18,7 +18,7 @@ defmodule Tentacat.PullsTest do
   end
 
   test "filter/4" do
-    use_cassette "pulls#filter" do
+    use_cassette "pulls#filter", match_requests_on: [:query] do
       assert elem(filter(@client, "tentatest", "tentacat", %{state: "closed"}), 1) == []
     end
   end
@@ -31,7 +31,7 @@ defmodule Tentacat.PullsTest do
   end
 
   test "create/4" do
-    use_cassette "pulls#create" do
+    use_cassette "pulls#create", match_requests_on: [:request_body] do
       body = %{
         "title" => "Amazing new Readme",
         "body" => "Every project needs a README",
@@ -45,7 +45,7 @@ defmodule Tentacat.PullsTest do
   end
 
   test "update/5" do
-    use_cassette "pulls#update" do
+    use_cassette "pulls#update", match_requests_on: [:request_body] do
       body = %{
         "state" => "closed"
       }
@@ -56,7 +56,7 @@ defmodule Tentacat.PullsTest do
   end
 
   test "merge/5" do
-    use_cassette "pulls#merge" do
+    use_cassette "pulls#merge", match_requests_on: [:request_body] do
       body = %{
         commit_message: "not the default commit_message"
       }

--- a/test/references_test.exs
+++ b/test/references_test.exs
@@ -25,7 +25,7 @@ defmodule Tentacat.ReferencesTest do
   end
 
   test "create/4" do
-    use_cassette "references#create" do
+    use_cassette "references#create", match_requests_on: [:request_body] do
       body = %{
         "ref" => "refs/heads/old-readme",
         "sha" => "2ff6f7942773c268dc9ab0e11e9dffad402c1860"
@@ -42,7 +42,7 @@ defmodule Tentacat.ReferencesTest do
       "force" => true
     }
 
-    use_cassette "references#update" do
+    use_cassette "references#update", match_requests_on: [:request_body] do
       {_, %{"ref" => ref}, _} =
         update(@client, "soudqwiggle", "elixir-conspiracy", "heads/master", body)
 

--- a/test/releases_test.exs
+++ b/test/releases_test.exs
@@ -32,16 +32,16 @@ defmodule Tentacat.ReleasesTest do
   end
 
   test "create/4" do
-    use_cassette "releases#create" do
+    use_cassette "releases#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "v1", "soudqwiggle", "elixir-conspiracy")
       assert status_code == 201
     end
   end
 
   test "edit/5" do
-    options = [tag_name: "v1.0.0"]
+    options = %{tag_name: "v1.0.0"}
 
-    use_cassette "releases#edit" do
+    use_cassette "releases#edit", match_requests_on: [:request_body] do
       {_, %{"tag_name" => name}, _} =
         edit(@client, 2_317_708, "soudqwiggle", "elixir-conspiracy", options)
 

--- a/test/repositories/branches_test.exs
+++ b/test/repositories/branches_test.exs
@@ -32,7 +32,7 @@ defmodule Tentacat.Repositories.BranchesTest do
       "restrictions" => nil
     }
 
-    use_cassette "repositories/branches#update_protection" do
+    use_cassette "repositories/branches#update_protection", match_requests_on: [:request_body] do
       assert elem(update_protection(@client, "valiot", "tentacat", "master", body), 1)["url"] ==
                "https://api.github.com/repos/valiot/tentacat/branches/master/protection"
     end

--- a/test/repositories/deploy_keys_test.exs
+++ b/test/repositories/deploy_keys_test.exs
@@ -25,7 +25,7 @@ defmodule Tentacat.Repositories.DeployKeysTest do
   end
 
   test "create/4" do
-    use_cassette "repositories/deploy_keys#create" do
+    use_cassette "repositories/deploy_keys#create", match_requests_on: [:request_body] do
       key =
         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCc72ESoMRGBQJBjnUUSNo1uoRnV7PI82KtqfSLjcmj3fUB0OvVx8haMhtb7hlxKb5J7J2vLNONyRgNryUkOFTwfHpCt0TZqCKMvp9AuYyAQH2E1kbIGPQ/6BTCktGXq200Ua2hM5NNZjuCgxgMNoyxMzoSb5qChCXatQLIzbODBhyMEPwUq3PqAieirCEPIjXRr2jEAR9+xL8UnHb2e3ZcjuqZPB+yiZZSzZA5IDs3zW7RBQB6ZLoIInUWRxR41YE/2gNeUe4FwhXfxXane/4zkiNqqClE2rDo25MocVpqzP8niVuwQYPYsxEGOo/RIaQa55wvD/LMIwEaOVdbnRl7"
 

--- a/test/repositories/deployments_test.exs
+++ b/test/repositories/deployments_test.exs
@@ -24,7 +24,7 @@ defmodule Tentacat.Repositories.DeploymentsTest do
       "description" => "Deploying my sweet branch"
     }
 
-    use_cassette "repositories/deployments#create" do
+    use_cassette "repositories/deployments#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", body)
       assert status_code == 201
     end
@@ -43,7 +43,7 @@ defmodule Tentacat.Repositories.DeploymentsTest do
       description: "Deployment finished successfully."
     }
 
-    use_cassette "repositories/deployments#create_status" do
+    use_cassette "repositories/deployments#create_status", match_requests_on: [:request_body] do
       {status_code, _, _} =
         create_status(@client, "soudqwiggle", "elixir-conspiracy", 2_936_534, body)
 

--- a/test/repositories/forks_test.exs
+++ b/test/repositories/forks_test.exs
@@ -21,7 +21,7 @@ defmodule Tentacat.Repositories.ForksTest do
   end
 
   test "create/4" do
-    use_cassette "repositories/forks#create" do
+    use_cassette "repositories/forks#create", match_requests_on: [:request_body] do
       {status_code, %{"owner" => %{"login" => owner}}, _} =
         create(@client, "ShaneWilton", "tentacat", %{})
 

--- a/test/repositories/labels_test.exs
+++ b/test/repositories/labels_test.exs
@@ -34,7 +34,7 @@ defmodule Tentacat.Repositories.LabelsTest do
   end
 
   test "create/4" do
-    use_cassette "repositories/labels#create" do
+    use_cassette "repositories/labels#create", match_requests_on: [:request_body] do
       {status_code, %{"name" => name, "color" => color}, _} =
         create(@client, "danielfarrell", "elixir", %{name: "WIP", color: "123456"})
 
@@ -45,7 +45,7 @@ defmodule Tentacat.Repositories.LabelsTest do
   end
 
   test "update/5" do
-    use_cassette "repositories/labels#update" do
+    use_cassette "repositories/labels#update", match_requests_on: [:request_body] do
       %{"name" => name, "color" => color} =
         elem(update(@client, "danielfarrell", "elixir", "WIP", %{color: "654321"}), 1)
 

--- a/test/repositories/projects_test.exs
+++ b/test/repositories/projects_test.exs
@@ -25,9 +25,9 @@ defmodule Tentacat.Repositories.ProjectsTest do
   end
 
   test "create/4" do
-    use_cassette "repositories/projects#create" do
+    use_cassette "repositories/projects#create", match_requests_on: [:request_body] do
       {status, _response, _} =
-        create(@client, "achiurizo", "dotfiles", name: "tentacat", body: "my new project")
+        create(@client, "achiurizo", "dotfiles", %{name: "tentacat", body: "my new project"})
 
       assert status == 201
     end

--- a/test/repositories/statuses_test.exs
+++ b/test/repositories/statuses_test.exs
@@ -47,7 +47,7 @@ defmodule Tentacat.Repositories.StatusesTest do
       context: "continuous-integration/jenkins"
     }
 
-    use_cassette "repositories/statuses#create" do
+    use_cassette "repositories/statuses#create", match_requests_on: [:request_body] do
       {status_code, _, _} =
         create(
           @client,

--- a/test/repositories_test.exs
+++ b/test/repositories_test.exs
@@ -83,15 +83,15 @@ defmodule Tentacat.RepositoriesTest do
   end
 
   test "create/3" do
-    use_cassette "repositories#create" do
-      {status, _response, _} = create(@client, "tentacat", private: false)
+    use_cassette "repositories#create", match_requests_on: [:request_body] do
+      {status, _response, _} = create(@client, "tentacat", %{private: false})
       assert status == 201
     end
   end
 
   test "org_create/4" do
-    use_cassette "repositories#org_create" do
-      {status, _response, _} = org_create(@client, "tentatest", "tentacat", private: false)
+    use_cassette "repositories#org_create", match_requests_on: [:request_body] do
+      {status, _response, _} = org_create(@client, "tentatest", "tentacat", %{private: false})
       assert status == 201
     end
   end

--- a/test/users/keys_test.exs
+++ b/test/users/keys_test.exs
@@ -43,14 +43,14 @@ sOpeb6IzgbBaxuQ9Jlpu2JgzMst0ArBNkPI3ER6ppQ== your_email@example.com "
   end
 
   test "create/3" do
-    use_cassette "users/keys#create" do
+    use_cassette "users/keys#create", match_requests_on: [:request_body] do
       {status_code, _, _} = create(@client, "test key", @public_key)
       assert status_code == 201
     end
   end
 
   test "update/4" do
-    use_cassette "users/keys#update" do
+    use_cassette "users/keys#update", match_requests_on: [:request_body] do
       {405, %{"message" => message}, _} =
         update(@client, 15_057_833, "updated test key", "ssh-rsa AAA...")
 


### PR DESCRIPTION
It fixes #193 

This forces body arguments to be maps. The guard `is_map` will blow up if a keyword/list is passed. This will hopefully be useful for people upgrading to Tentacat 2.0.* 