### PR TITLE
Delete reactions endpoint for Issues and its comments

### DIFF
--- a/lib/tentacat/issues/comments/reactions.ex
+++ b/lib/tentacat/issues/comments/reactions.ex
@@ -36,4 +36,22 @@ defmodule Tentacat.Issues.Comments.Reactions do
   def create(client \\ %Client{}, owner, repo, comment_id, body) when is_map(body) do
     post("repos/#{owner}/#{repo}/issues/comments/#{comment_id}/reactions", client, body)
   end
+
+  @doc """
+  Delete a reaction on an issue comment
+
+  ### Example
+
+  Tentacat.Issues.Comments.Reactions.delete "elixir-lang", "elixir", "3", "4", client
+
+  More info at: https://developer.github.com/v3/reactions/#delete-an-issue-comment-reaction
+  """
+  @spec delete(Client.t(), binary, binary, binary | integer, binary) ::
+          Tentacat.response()
+  def delete(client \\ %Client{}, owner, repo, comment_id, reaction_id) do
+    delete(
+      "repos/#{owner}/#{repo}/issues/comments/#{comment_id}/reactions/#{reaction_id}",
+      client
+    )
+  end
 end

--- a/lib/tentacat/issues/reactions.ex
+++ b/lib/tentacat/issues/reactions.ex
@@ -36,4 +36,19 @@ defmodule Tentacat.Issues.Reactions do
   def create(client \\ %Client{}, owner, repo, issue_id, body) do
     post("repos/#{owner}/#{repo}/issues/#{issue_id}/reactions", client, body)
   end
+
+  @doc """
+  Delete a reaction on an issue
+
+  ### Example
+
+  Tentacat.Issues.Reactions.delete "elixir-lang", "elixir", "3", "4"
+
+  More info at: https://developer.github.com/v3/reactions/#delete-an-issue-reaction
+  """
+  @spec delete(Client.t(), binary, binary, binary | integer, binary) ::
+          Tentacat.response()
+  def delete(client \\ %Client{}, owner, repo, issue_id, reaction_id) do
+    delete("repos/#{owner}/#{repo}/issues/#{issue_id}/reactions/#{reaction_id}", client)
+  end
 end

--- a/test/fixture/vcr_cassettes/issues/comments/reactions#delete.json
+++ b/test/fixture/vcr_cassettes/issues/comments/reactions#delete.json
@@ -1,0 +1,43 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/dwyl/learn-elixir/issues/comments/1/reactions/2"
+    },
+    "response": {
+      "body": "",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Wed, 19 Apr 2017 15:38:42 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2260",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "60",
+        "X-RateLimit-Remaining": "42",
+        "X-RateLimit-Reset": "1465314971",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"1598b9c2c9191001f30226e51a54afb2\"",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "318e55760cf7cdb40e61175a4d36cd32",
+        "X-GitHub-Request-Id": "32E9B27E:B216:239A2390:5756E46C"
+      },
+      "status_code": 204,
+      "type": "ok"
+    }
+  }
+]

--- a/test/fixture/vcr_cassettes/issues/reactions#delete.json
+++ b/test/fixture/vcr_cassettes/issues/reactions#delete.json
@@ -1,0 +1,43 @@
+[
+  {
+    "request": {
+      "body": "\"\"",
+      "headers": {
+        "User-agent": "tentacat",
+        "Authorization": "token yourtokencomeshere"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.github.com/repos/dwyl/learn-elixir/issues/1/reactions/2"
+    },
+    "response": {
+      "body": "",
+      "headers": {
+        "Server": "GitHub.com",
+        "Date": "Wed, 19 Apr 2017 15:38:42 GMT",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2260",
+        "Status": "200 OK",
+        "X-RateLimit-Limit": "60",
+        "X-RateLimit-Remaining": "42",
+        "X-RateLimit-Reset": "1465314971",
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Vary": "Accept",
+        "ETag": "\"1598b9c2c9191001f30226e51a54afb2\"",
+        "X-GitHub-Media-Type": "github.v3; format=json",
+        "Access-Control-Expose-Headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+        "Access-Control-Allow-Origin": "*",
+        "Content-Security-Policy": "default-src 'none'",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "deny",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Served-By": "318e55760cf7cdb40e61175a4d36cd32",
+        "X-GitHub-Request-Id": "32E9B27E:B216:239A2390:5756E46C"
+      },
+      "status_code": 204,
+      "type": "ok"
+    }
+  }
+]

--- a/test/issues/comments/reactions_test.exs
+++ b/test/issues/comments/reactions_test.exs
@@ -26,4 +26,10 @@ defmodule Tentacat.Issues.Comments.ReactionsTest do
       assert {201, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "1", body)
     end
   end
+
+  test "delete/5" do
+    use_cassette "issues/comments/reactions#delete" do
+      assert {204, _, _} = delete(@client, "dwyl", "learn-elixir", "1", "2")
+    end
+  end
 end

--- a/test/issues/reactions_test.exs
+++ b/test/issues/reactions_test.exs
@@ -26,4 +26,10 @@ defmodule Tentacat.Issues.ReactionsTest do
       assert {201, _, _} = create(@client, "soudqwiggle", "elixir-conspiracy", "1", body)
     end
   end
+
+  test "delete/6" do
+    use_cassette "issues/reactions#delete" do
+      assert {204, _, _} = delete(@client, "dwyl", "learn-elixir", "1", "2")
+    end
+  end
 end

--- a/test/issues/reactions_test.exs
+++ b/test/issues/reactions_test.exs
@@ -27,7 +27,7 @@ defmodule Tentacat.Issues.ReactionsTest do
     end
   end
 
-  test "delete/6" do
+  test "delete/5" do
     use_cassette "issues/reactions#delete" do
       assert {204, _, _} = delete(@client, "dwyl", "learn-elixir", "1", "2")
     end


### PR DESCRIPTION
This PR adds support for two Reactions Delete endpoints:
1. Delete a reaction on an issue: https://developer.github.com/v3/reactions/#delete-an-issue-reaction
2. Delete a reaction on an issue comment: https://developer.github.com/v3/reactions/#delete-an-issue-comment-reaction

PartiallyCloses #187

I'll add other