### PR TITLE
Fix missing exvcr custome path causing error

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,7 @@ use Mix.Config
 if Mix.env() == :test do
   config :exvcr,
     vcr_cassette_library_dir: "test/fixture/vcr_cassettes",
+    custom_cassette_library_dir: "test/fixture/custom_cassettes",
     filter_sensitive_data: [
       [pattern: "token [^\"]+", placeholder: "token yourtokencomeshere"]
     ]


### PR DESCRIPTION
This PR fixes the issue when running the `MIX_ENV=test mix vcr` where missing `custom_cassette_library_dir` will default to `nil`.

```
...
** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1    
    
    The following arguments were given to IO.chardata_to_string/1:
    
        # 1
        nil
    
    Attempted function clauses (showing 2 out of 2):
    
        def chardata_to_string(string) when is_binary(string)
        def chardata_to_string(list) when is_list(list)
    
    (elixir 1.10.3) lib/io.ex:572: IO.chardata_to_string/1
    (elixir 1.10.3) lib/file.ex:214: File.exists?/2
    lib/exvcr/task/runner.ex:17: anonymous fn/1 in ExVCR.Task.Runner.show_vcr_cassettes/1
    (elixir 1.10.3) lib/enum.ex:783: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir 1.10.3) lib/enum.ex:783: Enum.each/2
    (mix 1.10.3) lib/mix/task.ex:330: Mix.Task.run_task/3
    (mix 1.10.3) lib/mix/cli.ex:82: Mix.CLI.run_task/2

```

